### PR TITLE
Fix: Fixed RNVideo crash when rate is set to 0.0. Using paused proper…

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -1261,7 +1261,13 @@ class ReactExoplayerView extends RelativeLayout implements LifecycleEventListene
     }
 
     public void setRateModifier(float newRate) {
-        rate = newRate;
+
+        if (newRate == 0.0) {
+            setPausedModifier(true);
+        } else {
+            setPausedModifier(false);
+            rate = newRate;
+        }
 
         if (player != null) {
             PlaybackParameters params = new PlaybackParameters(rate, 1f);


### PR DESCRIPTION
…ty instead. https://github.com/react-native-community/react-native-video/issues/1174