### PR TITLE
fix: Android seek to live window when resuming app

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -387,6 +387,10 @@ class ReactExoplayerView extends RelativeLayout implements LifecycleEventListene
     public void onHostResume() {
         if (!playInBackground || !isInBackground) {
             setPlayWhenReady(!isPaused);
+            // On live, ignore DVR and seek to the most recent position of the video
+            if(this.live && player != null) {
+                player.seekToDefaultPosition();
+            }
         }
         isInBackground = false;
     }


### PR DESCRIPTION
Android seek to live window when resuming app