### PR TITLE
Fix/dev 1747 video player audio menu default

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -160,6 +160,8 @@ class ReactExoplayerView extends RelativeLayout implements LifecycleEventListene
     private int bufferForPlaybackMs = DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_MS;
     private int bufferForPlaybackAfterRebufferMs = DefaultLoadControl.DEFAULT_BUFFER_FOR_PLAYBACK_AFTER_REBUFFER_MS;
 
+    private HashMap<String, Locale> localeMap = new HashMap<String, Locale>();
+
     // Props from React
     private Uri srcUri;
     private String extension;
@@ -907,14 +909,24 @@ class ReactExoplayerView extends RelativeLayout implements LifecycleEventListene
         TrackGroupArray groups = info.getTrackGroups(index);
         for (int i = 0; i < groups.length; ++i) {
             Format format = groups.get(i).getFormat(0);
+            String language = format.language != null ? format.language : "";
+            String languageCode = this.getIso2(language);
+
             WritableMap audioTrack = Arguments.createMap();
             audioTrack.putInt("index", i);
             audioTrack.putString("title", format.id != null ? format.id : "");
             audioTrack.putString("type", format.sampleMimeType);
-            audioTrack.putString("language", format.language != null ? format.language : "");
+            audioTrack.putString("language", languageCode);
             audioTracks.pushMap(audioTrack);
         }
         return audioTracks;
+    }
+
+    private String getIso2(String iso3) {
+        if (this.localeMap.containsKey(iso3)) {
+            return this.localeMap.get(iso3).toString();
+        }
+        return "";
     }
 
     private WritableArray getTextTrackInfo() {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -916,7 +916,7 @@ class ReactExoplayerView extends RelativeLayout implements LifecycleEventListene
         for (int i = 0; i < groups.length; ++i) {
             Format format = groups.get(i).getFormat(0);
             String language = format.language != null ? format.language : "";
-            String languageCode = this.getIso2(language);
+            String languageCode = this.getISO2(language);
 
             WritableMap audioTrack = Arguments.createMap();
             audioTrack.putInt("index", i);
@@ -928,7 +928,7 @@ class ReactExoplayerView extends RelativeLayout implements LifecycleEventListene
         return audioTracks;
     }
 
-    private String getIso2(String iso3) {
+    private String getISO2(String iso3) {
         if (this.localeMap.containsKey(iso3)) {
             return this.localeMap.get(iso3).toString();
         }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -265,7 +265,7 @@ class ReactExoplayerView extends RelativeLayout implements LifecycleEventListene
         String[] languages = Locale.getISOLanguages();
         for (String language : languages) {
             Locale locale = new Locale(language);
-            this.localeMap.put(locale.getISO3Language(), locale);
+            localeMap.put(locale.getISO3Language(), locale);
         }
     }
 
@@ -916,7 +916,7 @@ class ReactExoplayerView extends RelativeLayout implements LifecycleEventListene
         for (int i = 0; i < groups.length; ++i) {
             Format format = groups.get(i).getFormat(0);
             String language = format.language != null ? format.language : "";
-            String languageCode = this.getISO2(language);
+            String languageCode = getISO2(language);
 
             WritableMap audioTrack = Arguments.createMap();
             audioTrack.putInt("index", i);
@@ -929,8 +929,8 @@ class ReactExoplayerView extends RelativeLayout implements LifecycleEventListene
     }
 
     private String getISO2(String iso3) {
-        if (this.localeMap.containsKey(iso3)) {
-            return this.localeMap.get(iso3).toString();
+        if (localeMap.containsKey(iso3)) {
+            return localeMap.get(iso3).getLanguage();
         }
         return "";
     }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -261,6 +261,12 @@ class ReactExoplayerView extends RelativeLayout implements LifecycleEventListene
             }
         };
         gestureDetector = new GestureDetectorCompat(themedReactContext, gestureListener);
+
+        String[] languages = Locale.getISOLanguages();
+        for (String language : languages) {
+            Locale locale = new Locale(language);
+            this.localeMap.put(locale.getISO3Language(), locale);
+        }
     }
 
 

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -1397,7 +1397,7 @@ dispatch_queue_t delegateQueue;
         if (values.count > 0) {
             title = [values objectAtIndex:0];
         }
-        NSString *language = [currentOption extendedLanguageTag] ? [currentOption extendedLanguageTag] : @"";
+        NSString *language = [currentOption.locale languageCode] ? [currentOption.locale languageCode] : @"";
         NSDictionary *audioTrack = @{
                                     @"index": [NSNumber numberWithInt:i],
                                     @"title": title,


### PR DESCRIPTION
Video player to return 2-letter language codes (instead of 3-letter language codes) in audio tracks so that the correct default language track can be displayed in menu.