### PR TITLE
fix: remove flicker on changing controls prop

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -1522,20 +1522,13 @@ dispatch_queue_t delegateQueue;
 
 - (void)setControls:(BOOL)controls
 {
-  if( _controls != controls || (!_playerLayer && !_playerViewController) )
+  if( _controls != controls || !_playerViewController )
   {
-    _controls = controls;
-    if( _controls )
-    {
-      [self removePlayerLayer];
+    if(!_playerViewController) {
       [self usePlayerViewController];
     }
-    else
-    {
-      [_playerViewController.view removeFromSuperview];
-      _playerViewController = nil;
-      [self usePlayerLayer];
-    }
+    _controls = controls;
+    _playerViewController.showsPlaybackControls = _controls;
   }
 }
 


### PR DESCRIPTION
## Description
Remove flicker on setting the `controls` prop on tvOS. Use PlayerViewController everywhere instead of switching between playerLayer and PlayerViewController

See this [upstream Github Issue](https://github.com/react-native-community/react-native-video/issues/1374)