### PR TITLE
fix: AndroidTV seek indicator fixes.

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -1768,32 +1768,33 @@ class ReactTVExoplayerView extends RelativeLayout implements LifecycleEventListe
     }
 
     private void moveSeekBarIndicator(SeekBar seekbar, boolean isRew) {
-        int paddingLeft = previewSeekBarLayout.getPaddingLeft();
+        int paddingLeftX = previewSeekBarLayout.getPaddingLeft();
         int indicatorWidth = seekIndicator.getMeasuredWidth();
         Rect bounds = seekbar.getThumb().getBounds();
-        int thumbPos = (int) seekbar.getX() + bounds.centerX() + seekbar.getPaddingLeft();
+        int thumbPos = (int) seekbar.getX() + bounds.centerX() + seekbar.getThumbOffset();
 
-        //int indicatorX = thumbPos - (indicatorWidth / 2);
         int indicatorX = !isRew ?
                     thumbPos - ((indicatorWidth - seekIndicator.getForwardImageWidth()) / 2)
                 : thumbPos - ((indicatorWidth - seekIndicator.getRewImageWidth()) / 2) - seekIndicator.getRewImageWidth();
 
-        if (indicatorX < paddingLeft) {
-            indicatorX = paddingLeft;
-        } else if (indicatorX + indicatorWidth > previewSeekBarLayout.getMeasuredWidth() - previewSeekBarLayout.getPaddingRight()) {
-            indicatorX = previewSeekBarLayout.getMeasuredWidth() - previewSeekBarLayout.getPaddingRight() - indicatorWidth;
+        int paddingRightX = previewSeekBarLayout.getMeasuredWidth() - previewSeekBarLayout.getPaddingRight() - indicatorWidth;
+
+        if (indicatorX < paddingLeftX) {
+            indicatorX = paddingLeftX;
+        } else if (indicatorX > paddingRightX) {
+            indicatorX = paddingRightX;
         }
 
-        int thumbRectLeft = bounds.left;
-        int thumbRecCentre = bounds.centerX();
-        int thumbOffset = seekbar.getThumbOffset();
-        Log.d(TAG, "moveSeekBarIndicator()" +
-                " thumbRectLeft = " + thumbRectLeft +
-                " thumbRecCentre = " + thumbRecCentre +
-                " thumbOffset = " + thumbOffset +
-                " thumbPos=" + thumbPos +
-                " indicatorWidth=" + indicatorWidth +
-                " indicatorX=" + indicatorX);
+//        int thumbRectLeft = bounds.left;
+//        int thumbRecCentre = bounds.centerX();
+//        int thumbOffset = seekbar.getThumbOffset();
+//        Log.d(TAG, "moveSeekBarIndicator()" +
+//                " thumbRectLeft = " + thumbRectLeft +
+//                " thumbRecCentre = " + thumbRecCentre +
+//                " thumbOffset = " + thumbOffset +
+//                " thumbPos=" + thumbPos +
+//                " indicatorWidth=" + indicatorWidth +
+//                " indicatorX=" + indicatorX);
 
         seekIndicator.setX(indicatorX);
         animateShowView(seekIndicator, 0);

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -1785,17 +1785,6 @@ class ReactTVExoplayerView extends RelativeLayout implements LifecycleEventListe
             indicatorX = paddingRightX;
         }
 
-//        int thumbRectLeft = bounds.left;
-//        int thumbRecCentre = bounds.centerX();
-//        int thumbOffset = seekbar.getThumbOffset();
-//        Log.d(TAG, "moveSeekBarIndicator()" +
-//                " thumbRectLeft = " + thumbRectLeft +
-//                " thumbRecCentre = " + thumbRecCentre +
-//                " thumbOffset = " + thumbOffset +
-//                " thumbPos=" + thumbPos +
-//                " indicatorWidth=" + indicatorWidth +
-//                " indicatorX=" + indicatorX);
-
         seekIndicator.setX(indicatorX);
         animateShowView(seekIndicator, 0);
     }

--- a/android-exoplayer/src/main/res/layout/dce_seek_indicator.xml
+++ b/android-exoplayer/src/main/res/layout/dce_seek_indicator.xml
@@ -13,6 +13,8 @@
         android:scaleType="centerInside"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
+        android:scaleY="0.8"
+        android:scaleX="0.8"
         android:paddingTop="2dp"
         android:paddingBottom="2dp"/>
 
@@ -32,6 +34,8 @@
         android:scaleType="centerInside"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
+        android:scaleY="0.8"
+        android:scaleX="0.8"
         android:visibility="gone"
         android:paddingTop="2dp"
         android:paddingBottom="2dp" />


### PR DESCRIPTION
1. FF and REW indicators should be smaller. (80% of the text size)
2. / should be where the centre of thumb is.

![image](https://user-images.githubusercontent.com/40599365/65250914-45d26a00-daee-11e9-8852-36c6c3e67edd.png)
![image](https://user-images.githubusercontent.com/40599365/65250933-4f5bd200-daee-11e9-9fe3-34dba5c08cc5.png)
