### PR TITLE
fix: initalise player on BLW exception

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -731,6 +731,7 @@ class ReactExoplayerView extends RelativeLayout implements LifecycleEventListene
         resumePosition = C.TIME_UNSET;
     }
 
+
     /**
      * Returns a new DataSource factory.
      *
@@ -1035,8 +1036,8 @@ class ReactExoplayerView extends RelativeLayout implements LifecycleEventListene
         String errorString = null;
         Exception ex = e;
         if (isBehindLiveWindow(e)) {
-            errorString = getResources().getString(R.string.error_behind_live_window);
-            ex = new Exception("BehindLiveWindowException");
+            initializePlayer();
+            clearResumePosition();
         } else if (e.type == ExoPlaybackException.TYPE_RENDERER) {
             Exception cause = e.getRendererException();
             if (cause instanceof MediaCodecRenderer.DecoderInitializationException) {


### PR DESCRIPTION
# Description 
Currently we treat Behind Live Window exceptions as fatal. According to [Google Documentation](https://exoplayer.dev/hls.html#behindlivewindowexception ) we should catch the error reintialise the player and avoiding bubbling this error over the bridge to the JS video player component. 

To-do
*  When player is behind live window - reinitialise player and attempt to resume playback 


