### PR TITLE
Fix/controls prop repeat loop pause background

### DIFF
--- a/Video.js
+++ b/Video.js
@@ -221,7 +221,6 @@ export default class Video extends Component {
     Object.assign(nativeProps, {
       style: [styles.base, nativeProps.style],
       resizeMode: nativeResizeMode,
-      mediaKeys: this.props.mediaKeys,
       src: {
         uri,
         subtitles: source.subtitles,

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -166,6 +166,7 @@ class ReactTVExoplayerView extends RelativeLayout implements LifecycleEventListe
     private boolean isPaused;
     private boolean isBuffering;
     private boolean isMediaKeysEnabled = true;
+    private boolean isControlsVisible = true;
     private float rate = 1f;
     private int minBufferMs = DefaultLoadControl.DEFAULT_MIN_BUFFER_MS;
     private int maxBufferMs = DefaultLoadControl.DEFAULT_MAX_BUFFER_MS;
@@ -950,12 +951,22 @@ class ReactTVExoplayerView extends RelativeLayout implements LifecycleEventListe
                 text += "ended";
                 eventEmitter.end();
                 onStopPlayback();
+                if (
+                    player.getRepeatMode() == Player.REPEAT_MODE_ONE
+                    || player.getRepeatMode() == Player.REPEAT_MODE_ALL
+                    || this.repeat
+                ) {
+                    this.seekTo(0);
+                }
+
                 break;
             default:
                 text += "unknown";
                 break;
         }
-        updateControlsState();
+        if (isControlsVisible) {
+            updateControlsState();
+        }
         Log.d(TAG, text);
     }
 
@@ -1598,6 +1609,14 @@ class ReactTVExoplayerView extends RelativeLayout implements LifecycleEventListe
         });
     }
 
+    public void setControls(final boolean visible) {
+        if (visible) {
+            setControlsOpacity(1);
+        } else {
+            setControlsOpacity(0);
+        }
+    }
+
     public void setControlsOpacity(final float opacity) {
         float newTranslationY = ((1 - opacity) * bottomBarWidget.getHeight() * 0.5f);
         if (newTranslationY < 0) {
@@ -1857,6 +1876,9 @@ class ReactTVExoplayerView extends RelativeLayout implements LifecycleEventListe
     }
 
     public void showOverlay() {
+        if (this.repeat || !isControlsVisible) {
+            return;
+        }
 
         if (controlsAutoHideTimeout != null) {
             removeCallbacks(hideRunnable);

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -295,18 +295,6 @@ class ReactTVExoplayerView extends RelativeLayout implements LifecycleEventListe
     }
 
     private void createViews() {
-        addOnLayoutChangeListener(new OnLayoutChangeListener() {
-            @Override
-            public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop,
-                                       int oldRight, int oldBottom) {
-                postDelayed(new Runnable() {
-                    @Override
-                    public void run() {
-                        controls.requestLayout();
-                    }
-                }, 200);
-            }
-        });
         clearResumePosition();
         mediaDataSourceFactory = buildDataSourceFactory(true);
         mainHandler = new Handler();
@@ -314,113 +302,127 @@ class ReactTVExoplayerView extends RelativeLayout implements LifecycleEventListe
             CookieHandler.setDefault(DEFAULT_COOKIE_MANAGER);
         }
 
-        LayoutInflater inflater = LayoutInflater.from(getContext());
-
         LayoutParams layoutParams = new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);
         exoPlayerView = new ExoPlayerView(getContext());
         exoPlayerView.setLayoutParams(layoutParams);
         addView(exoPlayerView, 0, layoutParams);
         setLayoutTransition(new LayoutTransition());
 
-        controls = inflater.inflate(R.layout.controls_tv, null);
-        LayoutParams controlsParam = new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);
-        controls.setLayoutParams(controlsParam);
-        addView(controls);
-
-        bottomBarWidget = controls.findViewById(R.id.bottomBarWidget);
-
-        playPauseButton = (ImageButton) controls.findViewById(R.id.tvPlayPauseImageView);
-        playPauseButton.setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                setPausedModifier(!isPaused);
-            }
-        });
-        currentTextView = (TextView) controls.findViewById(R.id.currentTimeTextView);
-        liveTextView = (TextView) controls.findViewById(R.id.liveTextView);
-        previewSeekBarLayout = (PreviewSeekBarLayout) controls.findViewById(R.id.previewSeekBarLayout);
-        previewSeekBarLayout.setPreviewLoader(new PreviewLoader() {
-            @Override
-            public void loadPreview(long currentPosition, long max) {
-
-            }
-        });
-        bottomBarWidgetContainer = (LinearLayout) controls.findViewById(R.id.tvBottomBarWidgetContainer);
-
-        audioSubtitlesButton = findViewById(R.id.tvAudioSubtitlesBtn);
-        audioSubtitlesButton.setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(View v) {
-
-                if (!live) {
-                    setPausedModifier(true);
+        if (isControlsVisible) {
+            addOnLayoutChangeListener(new OnLayoutChangeListener() {
+                @Override
+                public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop,
+                                           int oldRight, int oldBottom) {
+                    postDelayed(new Runnable() {
+                        @Override
+                        public void run() {
+                            controls.requestLayout();
+                        }
+                    }, 200);
                 }
+            });
 
-                setStateOverlay(ControlState.HIDDEN.toString());
+            LayoutInflater inflater = LayoutInflater.from(getContext());
+            controls = inflater.inflate(R.layout.controls_tv, null);
+            LayoutParams controlsParam = new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);
+            controls.setLayoutParams(controlsParam);
+            addView(controls);
 
-                if (dialog != null) {
-                    dialog.dismiss();
-                    dialog = null;
+            bottomBarWidget = controls.findViewById(R.id.bottomBarWidget);
+
+            playPauseButton = (ImageButton) controls.findViewById(R.id.tvPlayPauseImageView);
+            playPauseButton.setOnClickListener(new OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    setPausedModifier(!isPaused);
                 }
+            });
+            currentTextView = (TextView) controls.findViewById(R.id.currentTimeTextView);
+            liveTextView = (TextView) controls.findViewById(R.id.liveTextView);
+            previewSeekBarLayout = (PreviewSeekBarLayout) controls.findViewById(R.id.previewSeekBarLayout);
+            previewSeekBarLayout.setPreviewLoader(new PreviewLoader() {
+                @Override
+                public void loadPreview(long currentPosition, long max) {
 
-                dialog = new DceTracksDialog(getContext(), 0);
-                dialog.setModel(new DcePlayerModel(getContext(), player, trackSelector));
-                dialog.setAccentColor(accentColor);
+                }
+            });
+            bottomBarWidgetContainer = (LinearLayout) controls.findViewById(R.id.tvBottomBarWidgetContainer);
 
-                dialog.show();
-            }
-        });
+            audioSubtitlesButton = findViewById(R.id.tvAudioSubtitlesBtn);
+            audioSubtitlesButton.setOnClickListener(new OnClickListener() {
+                @Override
+                public void onClick(View v) {
 
-        scheduleButton = findViewById(R.id.tvScheduleBtn);
+                    if (!live) {
+                        setPausedModifier(true);
+                    }
 
-        scheduleButton.setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                eventEmitter.epgIconClick();
-                setStateOverlay(ControlState.HIDDEN.toString());
-            }
-        });
+                    setStateOverlay(ControlState.HIDDEN.toString());
 
-        statsButton = findViewById(R.id.tvStatsBtn);
+                    if (dialog != null) {
+                        dialog.dismiss();
+                        dialog = null;
+                    }
 
-        statsButton.setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                eventEmitter.statsIconClick();
-                setStateOverlay(ControlState.HIDDEN.toString());
-            }
-        });
+                    dialog = new DceTracksDialog(getContext(), 0);
+                    dialog.setModel(new DcePlayerModel(getContext(), player, trackSelector));
+                    dialog.setAccentColor(accentColor);
 
-        labelTextView = findViewById(R.id.tvLabelView);
+                    dialog.show();
+                }
+            });
 
-        bottomBarWidget.getViewTreeObserver().addOnGlobalFocusChangeListener(new ViewTreeObserver.OnGlobalFocusChangeListener() {
-            @Override
-            public void onGlobalFocusChanged(View oldFocus, View newFocus) {
-                Log.d(TAG, "onGlobalFocusChanged()");
+            scheduleButton = findViewById(R.id.tvScheduleBtn);
 
-                updateLabelView(newFocus);
-            }
-        });
+            scheduleButton.setOnClickListener(new OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    eventEmitter.epgIconClick();
+                    setStateOverlay(ControlState.HIDDEN.toString());
+                }
+            });
 
-        setEpg(false); // default value
-        setStats(false);
+            statsButton = findViewById(R.id.tvStatsBtn);
 
-        setupButton(playPauseButton);
-        setupButton(audioSubtitlesButton);
-        setupButton(scheduleButton);
-        setupButton(statsButton);
+            statsButton.setOnClickListener(new OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    eventEmitter.statsIconClick();
+                    setStateOverlay(ControlState.HIDDEN.toString());
+                }
+            });
 
-        // RN: Android native UI components are not re-layout on dynamically added views. Fix for View.GONE -> View.VISIBLE issue.
-        Choreographer.getInstance().postFrameCallback(new Choreographer.FrameCallback() {
-            @Override
-            public void doFrame(long frameTimeNanos) {
-                manuallyLayoutChildren();
-                getViewTreeObserver().dispatchOnGlobalLayout();
-                Choreographer.getInstance().postFrameCallback(this);
-            }
-        });
+            labelTextView = findViewById(R.id.tvLabelView);
 
-        seekIndicator = findViewById(R.id.seekIndicator);
+            bottomBarWidget.getViewTreeObserver().addOnGlobalFocusChangeListener(new ViewTreeObserver.OnGlobalFocusChangeListener() {
+                @Override
+                public void onGlobalFocusChanged(View oldFocus, View newFocus) {
+                    Log.d(TAG, "onGlobalFocusChanged()");
+
+                    updateLabelView(newFocus);
+                }
+            });
+
+            setEpg(false); // default value
+            setStats(false);
+
+            setupButton(playPauseButton);
+            setupButton(audioSubtitlesButton);
+            setupButton(scheduleButton);
+            setupButton(statsButton);
+
+            // RN: Android native UI components are not re-layout on dynamically added views. Fix for View.GONE -> View.VISIBLE issue.
+            Choreographer.getInstance().postFrameCallback(new Choreographer.FrameCallback() {
+                @Override
+                public void doFrame(long frameTimeNanos) {
+                    manuallyLayoutChildren();
+                    getViewTreeObserver().dispatchOnGlobalLayout();
+                    Choreographer.getInstance().postFrameCallback(this);
+                }
+            });
+
+            seekIndicator = findViewById(R.id.seekIndicator);
+        }
     }
 
     private void updateLabelView(View newFocus) {
@@ -1610,11 +1612,8 @@ class ReactTVExoplayerView extends RelativeLayout implements LifecycleEventListe
     }
 
     public void setControls(final boolean visible) {
-        if (visible) {
-            setControlsOpacity(1);
-        } else {
-            setControlsOpacity(0);
-        }
+        controls.setVisibility(visible ? VISIBLE : GONE);
+        isControlsVisible = visible;
     }
 
     public void setControlsOpacity(final float opacity) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -166,7 +166,7 @@ class ReactTVExoplayerView extends RelativeLayout implements LifecycleEventListe
     private boolean isPaused;
     private boolean isBuffering;
     private boolean isMediaKeysEnabled = true;
-    private boolean isControlsVisible = true;
+    private boolean areControlsVisible = true;
     private float rate = 1f;
     private int minBufferMs = DefaultLoadControl.DEFAULT_MIN_BUFFER_MS;
     private int maxBufferMs = DefaultLoadControl.DEFAULT_MAX_BUFFER_MS;
@@ -308,7 +308,7 @@ class ReactTVExoplayerView extends RelativeLayout implements LifecycleEventListe
         addView(exoPlayerView, 0, layoutParams);
         setLayoutTransition(new LayoutTransition());
 
-        if (isControlsVisible) {
+        if (areControlsVisible) {
             addOnLayoutChangeListener(new OnLayoutChangeListener() {
                 @Override
                 public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft, int oldTop,
@@ -966,7 +966,7 @@ class ReactTVExoplayerView extends RelativeLayout implements LifecycleEventListe
                 text += "unknown";
                 break;
         }
-        if (isControlsVisible) {
+        if (areControlsVisible) {
             updateControlsState();
         }
         Log.d(TAG, text);
@@ -1613,7 +1613,7 @@ class ReactTVExoplayerView extends RelativeLayout implements LifecycleEventListe
 
     public void setControls(final boolean visible) {
         controls.setVisibility(visible ? VISIBLE : GONE);
-        isControlsVisible = visible;
+        areControlsVisible = visible;
     }
 
     public void setControlsOpacity(final float opacity) {
@@ -1875,7 +1875,7 @@ class ReactTVExoplayerView extends RelativeLayout implements LifecycleEventListe
     }
 
     public void showOverlay() {
-        if (this.repeat || !isControlsVisible) {
+        if (this.repeat || !areControlsVisible) {
             return;
         }
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -474,10 +474,10 @@ class ReactTVExoplayerView extends RelativeLayout implements LifecycleEventListe
 
     @Override
     public void onHostPause() {
-        isInBackground = true;
         setPlayInBackground(false);
         setPlayWhenReady(false);
-        stopPlayback();
+        onStopPlayback();
+        isInBackground = true;
     }
 
     @Override

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
@@ -63,6 +63,7 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
     private static final String PROP_LIVE = "live";
     private static final String PROP_EPG = "hasEpg";
     private static final String PROP_STATS = "hasStats";
+    private static final String PROP_CONTROLS = "controls";
     private static final String PROP_CONTROLS_OPACITY = "controlsOpacity";
     private static final String PROP_PROGRESS_BAR_MARGIN_BOTTOM = "progressBarMarginBottom";
     private static final String PROP_STATE_OVERLAY = "stateOverlay";
@@ -267,6 +268,11 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
     @ReactProp(name = PROP_STATS, defaultBoolean = false)
     public void setStats(final ReactTVExoplayerView videoView, final boolean hasStats) {
         videoView.setStats(hasStats);
+    }
+
+    @ReactProp(name = PROP_CONTROLS)
+    public void setControls(final ReactTVExoplayerView videoView, final boolean visible) {
+        videoView.setControls(visible);
     }
 
     @ReactProp(name = PROP_CONTROLS_OPACITY)


### PR DESCRIPTION
- [x] [Android TV] Handle `controls` prop correctly
- [x] [Android TV] Fix `repeat` prop functionality
- [x] [Android TV] Prevent initial button instantiation based on `controls` prop
- [x] [Android TV] Pause player when it's in the background without the need to re-initialise player when returning to 'active' state