### PR TITLE
fix: adding text tracks on init as part of source

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -474,8 +474,8 @@ class ReactTVExoplayerView extends RelativeLayout implements LifecycleEventListe
 
     @Override
     public void onHostResume() {
-        Log.d(TAG, "onHostResume() isPaused: " + isPaused + " live: " + live);
         if (isInBackground) {
+            Log.d(TAG, "onHostResume() isPaused: " + isPaused + " live: " + live);
             isInBackground = false; // reset to false first
             if (live) {
                 // always seek to live edge when returning from background to a live event
@@ -565,7 +565,7 @@ class ReactTVExoplayerView extends RelativeLayout implements LifecycleEventListe
 
             PlaybackParameters params = new PlaybackParameters(rate, 1f);
             player.setPlaybackParameters(params);
-            Log.d(TAG, "initialisePlayer() new instance");
+            Log.d(TAG, "initialisePlayer() new instance: " + force);
 
             activateMediaSession();
         }
@@ -804,6 +804,7 @@ class ReactTVExoplayerView extends RelativeLayout implements LifecycleEventListe
     }
 
     private void releasePlayer() {
+        Log.d(TAG, "releasePlayer()");
         deactivateMediaSession();
         releaseMediaSession();
 
@@ -1382,7 +1383,7 @@ class ReactTVExoplayerView extends RelativeLayout implements LifecycleEventListe
     // ReactExoplayerViewManager public api
 
     public void setSrc(@NonNull final Uri uri, @Nullable final String extension, @Nullable final ActionToken actionToken,
-                       @Nullable final Map<String, String> headers,  @Nullable final Map<String, Object> muxData) {
+                       @Nullable final Map<String, String> headers,  @Nullable final Map<String, Object> muxData, final ReadableArray textTracks) {
         if (uri != null) {
             boolean isOriginalSourceNull = srcUri == null;
             boolean isSourceEqual = uri.equals(srcUri);
@@ -1393,13 +1394,14 @@ class ReactTVExoplayerView extends RelativeLayout implements LifecycleEventListe
             this.requestHeaders = headers;
             this.mediaDataSourceFactory = buildDataSourceFactory(true);
             this.muxData = muxData;
+            this.textTracks = textTracks;
 
             initializePlayer(!isOriginalSourceNull && !isSourceEqual);
         }
     }
 
     public void setSrc(@NonNull final Uri uri, @Nullable final String extension, @Nullable final Map<String, String> headers) {
-        setSrc(uri, extension, null, headers, null);
+        setSrc(uri, extension, null, headers, null, null);
     }
 
     public void setProgressUpdateInterval(final float progressUpdateInterval) {
@@ -1417,11 +1419,6 @@ class ReactTVExoplayerView extends RelativeLayout implements LifecycleEventListe
 
             initializePlayer(!isOriginalSourceNull && !isSourceEqual);
         }
-    }
-
-    public void setTextTracks(ReadableArray textTracks) {
-        this.textTracks = textTracks;
-        initializePlayer(true);
     }
 
     public void setResizeModeModifier(@ResizeMode.Mode int resizeMode) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
@@ -43,7 +43,7 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
     private static final String PROP_SELECTED_TEXT_TRACK = "selectedTextTrack";
     private static final String PROP_SELECTED_TEXT_TRACK_TYPE = "type";
     private static final String PROP_SELECTED_TEXT_TRACK_VALUE = "value";
-    private static final String PROP_TEXT_TRACKS = "textTracks";
+    private static final String PROP_SUBTITLES = "subtitles";
     private static final String PROP_PAUSED = "paused";
     private static final String PROP_MUTED = "muted";
     private static final String PROP_MEDIA_KEYS = "mediaKeys";
@@ -126,6 +126,7 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
         String drm = src.hasKey(PROP_SRC_DRM) ? src.getString(PROP_SRC_DRM) : null;
         Map<String, String> headers = src.hasKey(PROP_SRC_HEADERS) ? toStringMap(src.getMap(PROP_SRC_HEADERS)) : null;
 
+        ReadableArray textTracks = src.hasKey(PROP_SUBTITLES) ? src.getArray(PROP_SUBTITLES) : null;
         ReadableMap config = src.hasKey(PROP_SRC_CONFIG) ? src.getMap(PROP_SRC_CONFIG) : null;
         ReadableMap muxData = (config != null && config.hasKey(PROP_SRC_MUX_DATA)) ? config.getMap(PROP_SRC_MUX_DATA) : null;
 
@@ -138,7 +139,7 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
             ActionToken actionToken = ActionToken.fromJson(drm);
 
             if (srcUri != null) {
-                videoView.setSrc(srcUri, extension, actionToken, headers, muxData != null ? muxData.toHashMap() : null);
+                videoView.setSrc(srcUri, extension, actionToken, headers, muxData != null ? muxData.toHashMap() : null, textTracks);
             }
         } else {
             int identifier = context.getResources().getIdentifier(
@@ -198,12 +199,6 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
                     ? selectedTextTrack.getDynamic(PROP_SELECTED_TEXT_TRACK_VALUE) : null;
         }
         videoView.setSelectedTextTrack(typeString, value);
-    }
-
-    @ReactProp(name = PROP_TEXT_TRACKS)
-    public void setPropTextTracks(final ReactTVExoplayerView videoView,
-                                  @Nullable ReadableArray textTracks) {
-        videoView.setTextTracks(textTracks);
     }
 
     @ReactProp(name = PROP_PAUSED, defaultBoolean = false)


### PR DESCRIPTION
## Changes
* Passing subtitle tex tracks as part of the `source` prop under the `subtitles` property.

## Deprecated
* `textTracks` React-Native prop

## Example

```jsx
<RNVideo
  source={{
    uri: 'https://example.com',
    subtitles: hasSubtitles ? subtitles : undefined
  }}
/>
```