### PR TITLE
Fix: Version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "4.0.1",
+    "version": "5.0.0",
     "description": "A <Video /> element for react-native",
     "main": "Video.js",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "description": "A <Video /> element for react-native",
     "main": "Video.js",
     "license": "MIT",


### PR DESCRIPTION
## Description
A tag for version 4.0.0 of this library was previously created, so to be safe the first version with ExoDoris will be version 5.0.0.

## To Do
- [x] Bump library version to `5.0.0`