### PR TITLE
Feat/add live ui

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/entity/RNTranslations.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/entity/RNTranslations.java
@@ -26,6 +26,7 @@ public class RNTranslations {
     private static final String DEFAULT_MORE_VIDEOS_LABEL = "More Videos";
     private static final String DEFAULT_WATCH_LIST_LABEL = "Watch List";
 
+    private final Map<String, Object> translations;
     private final String epgLabel;
     private final String statsLabel;
     private final String playLabel;
@@ -37,29 +38,21 @@ public class RNTranslations {
     private final String watchListLabel;
 
     public RNTranslations(@NonNull Map<String, Object> translations) {
-        this.epgLabel = getStringFromMap(translations, KEY_EPG_LABEL, DEFAULT_EPG_LABEL);
-        this.statsLabel = getStringFromMap(translations, KEY_STATS_LABEL, DEFAULT_STATS_LABEL);
-        this.playLabel = getStringFromMap(translations, KEY_PLAY_LABEL, DEFAULT_PLAY_LABEL);
-        this.pauseLabel = getStringFromMap(translations, KEY_PAUSE_LABEL, DEFAULT_PAUSE_LABEL);
-        this.audioAndSubtitlesLabel = getStringFromMap(translations,
-                                                       KEY_AUDIO_AND_SUBTITLES_LABEL,
+        this.translations = translations;
+
+        this.epgLabel = getStringFromMap(KEY_EPG_LABEL, DEFAULT_EPG_LABEL);
+        this.statsLabel = getStringFromMap(KEY_STATS_LABEL, DEFAULT_STATS_LABEL);
+        this.playLabel = getStringFromMap(KEY_PLAY_LABEL, DEFAULT_PLAY_LABEL);
+        this.pauseLabel = getStringFromMap(KEY_PAUSE_LABEL, DEFAULT_PAUSE_LABEL);
+        this.audioAndSubtitlesLabel = getStringFromMap(KEY_AUDIO_AND_SUBTITLES_LABEL,
                                                        DEFAULT_AUDIO_AND_SUBTITLES_LABEL);
-        this.liveLabel = getStringFromMap(translations, KEY_LIVE_LABEL, DEFAULT_LIVE_LABEL);
-        this.favoriteLabel = getStringFromMap(translations,
-                                              KEY_FAVORITE_LABEL,
-                                              DEFAULT_FAVORITE_LABEL);
-        this.moreVideosLabel = getStringFromMap(translations,
-                                                KEY_MORE_VIDEOS_LABEL,
-                                                DEFAULT_MORE_VIDEOS_LABEL);
-        this.watchListLabel = getStringFromMap(translations,
-                                               KEY_WATCH_LIST_LABEL,
-                                               DEFAULT_WATCH_LIST_LABEL);
+        this.liveLabel = getStringFromMap(KEY_LIVE_LABEL, DEFAULT_LIVE_LABEL);
+        this.favoriteLabel = getStringFromMap(KEY_FAVORITE_LABEL, DEFAULT_FAVORITE_LABEL);
+        this.moreVideosLabel = getStringFromMap(KEY_MORE_VIDEOS_LABEL, DEFAULT_MORE_VIDEOS_LABEL);
+        this.watchListLabel = getStringFromMap(KEY_WATCH_LIST_LABEL, DEFAULT_WATCH_LIST_LABEL);
     }
 
-    private String getStringFromMap(
-            Map<String, Object> translations,
-            String key,
-            String defaultValue) {
+    private String getStringFromMap(String key, String defaultValue) {
         return translations.get(key) != null ? (String) translations.get(key) : defaultValue;
     }
 

--- a/android-exoplayer/src/main/java/com/brentvatne/entity/RNTranslations.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/entity/RNTranslations.java
@@ -1,0 +1,104 @@
+package com.brentvatne.entity;
+
+import androidx.annotation.NonNull;
+
+import java.util.Map;
+
+public class RNTranslations {
+
+    private static final String KEY_EPG_LABEL = "player_epg_button";
+    private static final String KEY_STATS_LABEL = "player_stats_button";
+    private static final String KEY_PLAY_LABEL = "player_play_button";
+    private static final String KEY_PAUSE_LABEL = "player_pause_button";
+    private static final String KEY_AUDIO_AND_SUBTITLES_LABEL = "player_audio_and_subtitles_button";
+    private static final String KEY_LIVE_LABEL = "live";
+    private static final String KEY_FAVORITE_LABEL = "favourite";
+    private static final String KEY_MORE_VIDEOS_LABEL = "moreVideos";
+    private static final String KEY_WATCH_LIST_LABEL = "watchlist";
+
+    private static final String DEFAULT_EPG_LABEL = "Schedule";
+    private static final String DEFAULT_STATS_LABEL = "Stats";
+    private static final String DEFAULT_PLAY_LABEL = "Play";
+    private static final String DEFAULT_PAUSE_LABEL = "Pause";
+    private static final String DEFAULT_AUDIO_AND_SUBTITLES_LABEL = "Audio & Subtitles";
+    private static final String DEFAULT_LIVE_LABEL = "Live";
+    private static final String DEFAULT_FAVORITE_LABEL = "Favourite";
+    private static final String DEFAULT_MORE_VIDEOS_LABEL = "More Videos";
+    private static final String DEFAULT_WATCH_LIST_LABEL = "Watch List";
+
+    private final String epgLabel;
+    private final String statsLabel;
+    private final String playLabel;
+    private final String pauseLabel;
+    private final String audioAndSubtitlesLabel;
+    private final String liveLabel;
+    private final String favoriteLabel;
+    private final String moreVideosLabel;
+    private final String watchListLabel;
+
+    public RNTranslations(@NonNull Map<String, Object> translations) {
+        this.epgLabel = translations.get(KEY_EPG_LABEL) != null ?
+                        (String) translations.get(KEY_EPG_LABEL) :
+                        DEFAULT_EPG_LABEL;
+        this.statsLabel = translations.get(KEY_STATS_LABEL) != null ?
+                          (String) translations.get(KEY_STATS_LABEL) :
+                          DEFAULT_STATS_LABEL;
+        this.playLabel = translations.get(KEY_PLAY_LABEL) != null ?
+                         (String) translations.get(KEY_PLAY_LABEL) :
+                         DEFAULT_PLAY_LABEL;
+        this.pauseLabel = translations.get(KEY_PAUSE_LABEL) != null ?
+                          (String) translations.get(KEY_PAUSE_LABEL) :
+                          DEFAULT_PAUSE_LABEL;
+        this.audioAndSubtitlesLabel = translations.get(KEY_AUDIO_AND_SUBTITLES_LABEL) != null ?
+                                      (String) translations.get(KEY_AUDIO_AND_SUBTITLES_LABEL) :
+                                      DEFAULT_AUDIO_AND_SUBTITLES_LABEL;
+        this.liveLabel = translations.get(KEY_LIVE_LABEL) != null ?
+                         (String) translations.get(KEY_LIVE_LABEL) :
+                         DEFAULT_LIVE_LABEL;
+        this.favoriteLabel = translations.get(KEY_FAVORITE_LABEL) != null ?
+                             (String) translations.get(KEY_FAVORITE_LABEL) :
+                             DEFAULT_FAVORITE_LABEL;
+        this.moreVideosLabel = translations.get(KEY_MORE_VIDEOS_LABEL) != null ?
+                               (String) translations.get(KEY_MORE_VIDEOS_LABEL) :
+                               DEFAULT_MORE_VIDEOS_LABEL;
+        this.watchListLabel = translations.get(KEY_WATCH_LIST_LABEL) != null ?
+                              (String) translations.get(KEY_WATCH_LIST_LABEL) :
+                              DEFAULT_WATCH_LIST_LABEL;
+    }
+
+    public String getEpgLabel() {
+        return epgLabel;
+    }
+
+    public String getStatsLabel() {
+        return statsLabel;
+    }
+
+    public String getPlayLabel() {
+        return playLabel;
+    }
+
+    public String getPauseLabel() {
+        return pauseLabel;
+    }
+
+    public String getAudioAndSubtitlesLabel() {
+        return audioAndSubtitlesLabel;
+    }
+
+    public String getLiveLabel() {
+        return liveLabel;
+    }
+
+    public String getFavoriteLabel() {
+        return favoriteLabel;
+    }
+
+    public String getMoreVideosLabel() {
+        return moreVideosLabel;
+    }
+
+    public String getWatchListLabel() {
+        return watchListLabel;
+    }
+}

--- a/android-exoplayer/src/main/java/com/brentvatne/entity/RNTranslations.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/entity/RNTranslations.java
@@ -37,33 +37,30 @@ public class RNTranslations {
     private final String watchListLabel;
 
     public RNTranslations(@NonNull Map<String, Object> translations) {
-        this.epgLabel = translations.get(KEY_EPG_LABEL) != null ?
-                        (String) translations.get(KEY_EPG_LABEL) :
-                        DEFAULT_EPG_LABEL;
-        this.statsLabel = translations.get(KEY_STATS_LABEL) != null ?
-                          (String) translations.get(KEY_STATS_LABEL) :
-                          DEFAULT_STATS_LABEL;
-        this.playLabel = translations.get(KEY_PLAY_LABEL) != null ?
-                         (String) translations.get(KEY_PLAY_LABEL) :
-                         DEFAULT_PLAY_LABEL;
-        this.pauseLabel = translations.get(KEY_PAUSE_LABEL) != null ?
-                          (String) translations.get(KEY_PAUSE_LABEL) :
-                          DEFAULT_PAUSE_LABEL;
-        this.audioAndSubtitlesLabel = translations.get(KEY_AUDIO_AND_SUBTITLES_LABEL) != null ?
-                                      (String) translations.get(KEY_AUDIO_AND_SUBTITLES_LABEL) :
-                                      DEFAULT_AUDIO_AND_SUBTITLES_LABEL;
-        this.liveLabel = translations.get(KEY_LIVE_LABEL) != null ?
-                         (String) translations.get(KEY_LIVE_LABEL) :
-                         DEFAULT_LIVE_LABEL;
-        this.favoriteLabel = translations.get(KEY_FAVORITE_LABEL) != null ?
-                             (String) translations.get(KEY_FAVORITE_LABEL) :
-                             DEFAULT_FAVORITE_LABEL;
-        this.moreVideosLabel = translations.get(KEY_MORE_VIDEOS_LABEL) != null ?
-                               (String) translations.get(KEY_MORE_VIDEOS_LABEL) :
-                               DEFAULT_MORE_VIDEOS_LABEL;
-        this.watchListLabel = translations.get(KEY_WATCH_LIST_LABEL) != null ?
-                              (String) translations.get(KEY_WATCH_LIST_LABEL) :
-                              DEFAULT_WATCH_LIST_LABEL;
+        this.epgLabel = getStringFromMap(translations, KEY_EPG_LABEL, DEFAULT_EPG_LABEL);
+        this.statsLabel = getStringFromMap(translations, KEY_STATS_LABEL, DEFAULT_STATS_LABEL);
+        this.playLabel = getStringFromMap(translations, KEY_PLAY_LABEL, DEFAULT_PLAY_LABEL);
+        this.pauseLabel = getStringFromMap(translations, KEY_PAUSE_LABEL, DEFAULT_PAUSE_LABEL);
+        this.audioAndSubtitlesLabel = getStringFromMap(translations,
+                                                       KEY_AUDIO_AND_SUBTITLES_LABEL,
+                                                       DEFAULT_AUDIO_AND_SUBTITLES_LABEL);
+        this.liveLabel = getStringFromMap(translations, KEY_LIVE_LABEL, DEFAULT_LIVE_LABEL);
+        this.favoriteLabel = getStringFromMap(translations,
+                                              KEY_FAVORITE_LABEL,
+                                              DEFAULT_FAVORITE_LABEL);
+        this.moreVideosLabel = getStringFromMap(translations,
+                                                KEY_MORE_VIDEOS_LABEL,
+                                                DEFAULT_MORE_VIDEOS_LABEL);
+        this.watchListLabel = getStringFromMap(translations,
+                                               KEY_WATCH_LIST_LABEL,
+                                               DEFAULT_WATCH_LIST_LABEL);
+    }
+
+    private String getStringFromMap(
+            Map<String, Object> translations,
+            String key,
+            String defaultValue) {
+        return translations.get(key) != null ? (String) translations.get(key) : defaultValue;
     }
 
     public String getEpgLabel() {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -34,6 +34,7 @@ import android.widget.TextView;
 
 import com.brentvatne.entity.RNImaSource;
 import com.brentvatne.entity.RNSource;
+import com.brentvatne.entity.RNTranslations;
 import com.brentvatne.react.R;
 import com.brentvatne.receiver.AudioBecomingNoisyReceiver;
 import com.brentvatne.receiver.BecomingNoisyListener;
@@ -53,6 +54,8 @@ import com.diceplatform.doris.ext.ima.entity.ImaSource;
 import com.diceplatform.doris.ext.ima.entity.ImaSourceBuilder;
 import com.diceplatform.doris.ui.DorisPlayerView;
 import com.diceplatform.doris.ui.ExoDorisPlayerView;
+import com.diceplatform.doris.ui.entity.Labels;
+import com.diceplatform.doris.ui.entity.LabelsBuilder;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Dynamic;
 import com.facebook.react.bridge.LifecycleEventListener;
@@ -171,6 +174,7 @@ class ReactTVExoplayerView extends RelativeLayout
     // Props from React
     private RNSource src;
     private RNImaSource imaSrc;
+    private RNTranslations translations;
     private boolean repeat;
     private String audioTrackType;
     private Dynamic audioTrackValue;
@@ -1292,6 +1296,9 @@ class ReactTVExoplayerView extends RelativeLayout
 
             exoDorisPlayerView.setTitle(title);
             exoDorisPlayerView.setDescription(description);
+            exoDorisPlayerView.setIsLive(live);
+
+            setLabelsOnPLayerUi();
 
             initializePlayer(!isOriginalSourceNull && !isSourceEqual);
         }
@@ -1860,7 +1867,27 @@ class ReactTVExoplayerView extends RelativeLayout
             });
     }
 
-    public void applyTranslations() {
-        updateLabelView(bottomBarWidget.getFocusedChild());
+    public void applyTranslations(Map<String, Object> translations) {
+//        updateLabelView(bottomBarWidget.getFocusedChild());
+        this.translations = new RNTranslations(translations);
+        setLabelsOnPLayerUi();
+    }
+
+    private void setLabelsOnPLayerUi() {
+        if (exoDorisPlayerView != null && translations != null) {
+            Labels labels = new LabelsBuilder()
+                    .setEpgLabel(translations.getEpgLabel())
+                    .setStatsLabel(translations.getStatsLabel())
+                    .setPlayLabel(translations.getPlayLabel())
+                    .setPauseLabel(translations.getPauseLabel())
+                    .setAudioAndSubtitlesLabel(translations.getAudioAndSubtitlesLabel())
+                    .setLiveLabel(translations.getLiveLabel())
+                    .setFavoriteLabel(translations.getFavoriteLabel())
+                    .setMoreVideosLabel(translations.getMoreVideosLabel())
+                    .setWatchListLabel(translations.getWatchListLabel())
+                    .build();
+
+            exoDorisPlayerView.setLabels(labels);
+        }
     }
 }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -1587,7 +1587,9 @@ class ReactTVExoplayerView extends RelativeLayout
 
     public void setLive(final boolean live) {
         this.live = live;
-        exoDorisPlayerView.setIsLive(live);
+        if (exoDorisPlayerView != null) {
+            exoDorisPlayerView.setIsLive(live);
+        }
         if (liveTextView != null && currentTextView != null && previewSeekBarLayout != null) {
             liveTextView.setVisibility(live ? VISIBLE : GONE);
             @IntegerRes

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -1587,6 +1587,7 @@ class ReactTVExoplayerView extends RelativeLayout
 
     public void setLive(final boolean live) {
         this.live = live;
+        exoDorisPlayerView.setIsLive(live);
         if (liveTextView != null && currentTextView != null && previewSeekBarLayout != null) {
             liveTextView.setVisibility(live ? VISIBLE : GONE);
             @IntegerRes
@@ -1868,7 +1869,6 @@ class ReactTVExoplayerView extends RelativeLayout
     }
 
     public void applyTranslations(Map<String, Object> translations) {
-//        updateLabelView(bottomBarWidget.getFocusedChild());
         this.translations = new RNTranslations(translations);
         setLabelsOnPLayerUi();
     }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -1296,9 +1296,6 @@ class ReactTVExoplayerView extends RelativeLayout
 
             exoDorisPlayerView.setTitle(title);
             exoDorisPlayerView.setDescription(description);
-            exoDorisPlayerView.setIsLive(live);
-
-            setLabelsOnPLayerUi();
 
             initializePlayer(!isOriginalSourceNull && !isSourceEqual);
         }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
@@ -372,7 +372,7 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
     @ReactProp(name = PROP_TRANSLATIONS)
     public void setTranslations(final ReactTVExoplayerView videoView, @Nullable ReadableMap translations) {
         DiceLocalizedStrings.getInstance().updateTranslations(toStringMap(translations));
-        videoView.applyTranslations();
+        videoView.applyTranslations(translations != null ? translations.toHashMap() : null);
     }
 
     private boolean startsWithValidScheme(String uriString) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.5.1",
+    "version": "5.6.0",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",


### PR DESCRIPTION
## Description
Change player UI appropriately when the content being viewed is live content.

## To do
- [x] Hide the seek bar when live content is being played.
- [x] Show the `LIVE` button in the bottom right corner when live content is being played.
- [x] Add support for changing the button labels based on data received from the JS layer
- [x] Bump library version

## Screenshots
![Screenshot_1604941195](https://user-images.githubusercontent.com/5672768/98572024-0c8a2a00-22ad-11eb-9c65-43564fe616b9.png)
