### PR TITLE
fix: controls showing up event if controls set to false from JS side

### DIFF
--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -149,7 +149,7 @@ static int const RCTVideoUnset = -1;
 
 - (AVPlayerViewController*)createPlayerViewController:(AVDorisPlayer*)player {
     RCTVideoPlayerViewController* playerLayer= [[RCTVideoPlayerViewController alloc] init];
-    playerLayer.showsPlaybackControls = YES;
+    playerLayer.showsPlaybackControls = _controls;
     playerLayer.rctDelegate = self;
     playerLayer.view.frame = self.bounds;
     playerLayer.player = player;
@@ -1654,6 +1654,7 @@ dispatch_queue_t delegateQueue;
       }
       _controls = controls;
       _playerViewController.view.userInteractionEnabled = _controls;
+      _playerViewController.showsPlaybackControls = _controls;
     }
   #endif
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.6.5",
+    "version": "5.6.6",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",


### PR DESCRIPTION
fix controls showing up event if ```controls``` view prop set to ```false``` from JS side