### PR TITLE
Chore/send ad error events to js layer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.7.0",
+    "version": "5.8.0",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",


### PR DESCRIPTION
## Description
Add a method that allows handles `adErrorEvent`s and propagates them to the JS layer so an appropriate error message can be displayed.

## To do
- [x] Add method that handles `adErrorEvent`s and propagates them to the JS layer
- [x] Remove the setting of a fallback URL on the player
- [x] Bump library version