### PR TITLE
Fix: Up next

### DIFF
--- a/Video.tsx
+++ b/Video.tsx
@@ -105,7 +105,11 @@ export default class Video extends React.PureComponent<IVideoPlayer, IState> {
   };
 
   onRelatedVideosClicked = (event) => {
-      this.props.onRelatedVideoClicked?.(event.nativeEvent);
+    this.props.onRelatedVideoClicked?.(event.nativeEvent);
+  }
+
+  onRelatedVideosIconClicked = (event) => {
+    this.getVideoPlayerProps.onRelatedVideosIconClicked?.(event.nativeEvent);
   }
 
   onVideoAboutToEnd = (event) => {
@@ -170,6 +174,7 @@ export default class Video extends React.PureComponent<IVideoPlayer, IState> {
       onPlaybackResume: this.onPlaybackResume,
       onPlaybackRateChange: this.onPlaybackRateChange,
       onRelatedVideoClicked: this.onRelatedVideosClicked,
+      onRelatedVideosIconClicked: this.onRelatedVideosIconClicked,
       onVideoAboutToEnd: this.onVideoAboutToEnd,
     };
   };

--- a/Video.tsx
+++ b/Video.tsx
@@ -108,6 +108,10 @@ export default class Video extends React.PureComponent<IVideoPlayer, IState> {
       this.props.onRelatedVideoClicked?.(event.nativeEvent);
   }
 
+  onVideoAboutToEnd = (event) => {
+    this.props.onVideoAboutToEnd?.(event.nativeEvent);
+  }
+
   /**
    * seekTo jumps to a certain position for vod and live content
    * time parameter can be the following:
@@ -166,6 +170,7 @@ export default class Video extends React.PureComponent<IVideoPlayer, IState> {
       onPlaybackResume: this.onPlaybackResume,
       onPlaybackRateChange: this.onPlaybackRateChange,
       onRelatedVideoClicked: this.onRelatedVideosClicked,
+      onVideoAboutToEnd: this.onVideoAboutToEnd,
     };
   };
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -201,7 +201,16 @@ class ReactTVExoplayerView extends FrameLayout
                 if (player != null && player.getPlaybackState() == Player.STATE_READY && player.getPlayWhenReady()) {
                     long pos = player.getCurrentPosition();
                     long bufferedDuration = player.getBufferedPercentage() * player.getDuration() / 100;
+                    boolean isAboutToEnd;
+                    if (player.getDuration() - pos <= 10) {
+                        isAboutToEnd = true;
+                    } else {
+                        isAboutToEnd = false;
+                    }
+
                     eventEmitter.progressChanged(pos, bufferedDuration, player.getDuration());
+                    eventEmitter.videoAboutToEnd(isAboutToEnd);
+
                     progressHandler.removeMessages(SHOW_JS_PROGRESS);
                     msg = obtainMessage(SHOW_JS_PROGRESS);
                     sendMessageDelayed(msg, Math.round(mProgressUpdateInterval));

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
@@ -36,6 +36,7 @@ class VideoEventEmitter {
     private static final String EVENT_FULLSCREEN_DID_PRESENT = "onVideoFullscreenPlayerDidPresent";
     private static final String EVENT_FULLSCREEN_WILL_DISMISS = "onVideoFullscreenPlayerWillDismiss";
     private static final String EVENT_FULLSCREEN_DID_DISMISS = "onVideoFullscreenPlayerDidDismiss";
+    private static final String EVENT_VIDEO_ABOUT_TO_END = "onVideoAboutToEnd";
 
     private static final String EVENT_STALLED = "onPlaybackStalled";
     private static final String EVENT_RESUME = "onPlaybackResume";
@@ -82,7 +83,8 @@ class VideoEventEmitter {
             EVENT_EPG_ICON_CLICK,
             EVENT_STATS_ICON_CLICK,
             EVENT_RELATED_VIDEO_CLICKED,
-            EVENT_RELATED_VIDEOS_ICON_CLICKED
+            EVENT_RELATED_VIDEOS_ICON_CLICKED,
+            EVENT_VIDEO_ABOUT_TO_END
     };
 
     @Retention(RetentionPolicy.SOURCE)
@@ -113,7 +115,8 @@ class VideoEventEmitter {
                        EVENT_EPG_ICON_CLICK,
                        EVENT_STATS_ICON_CLICK,
                        EVENT_RELATED_VIDEO_CLICKED,
-                       EVENT_RELATED_VIDEOS_ICON_CLICKED
+                       EVENT_RELATED_VIDEOS_ICON_CLICKED,
+                       EVENT_VIDEO_ABOUT_TO_END
                })
     @interface VideoEvents {
     }
@@ -144,6 +147,7 @@ class VideoEventEmitter {
     private static final String EVENT_PROP_CONTROLS_VISIBLE = "controlsVisible";
     private static final String EVENT_PROP_TOUCH_ACTION_MOVE_DX = "dx";
     private static final String EVENT_PROP_TOUCH_ACTION_MOVE_DY = "dy";
+    private static final String EVENT_PROP_IS_ABOUT_TO_END = "isAboutToEnd";
 
     private static final String EVENT_PROP_ERROR = "error";
     private static final String EVENT_PROP_ERROR_STRING = "errorString";
@@ -159,8 +163,9 @@ class VideoEventEmitter {
         receiveEvent(EVENT_LOAD_START, null);
     }
 
-    void load(double duration, double currentPosition, int videoWidth, int videoHeight,
-              WritableArray audioTracks, WritableArray textTracks) {
+    void load(
+            double duration, double currentPosition, int videoWidth, int videoHeight,
+            WritableArray audioTracks, WritableArray textTracks) {
         WritableMap event = Arguments.createMap();
         event.putDouble(EVENT_PROP_DURATION, duration / 1000D);
         event.putDouble(EVENT_PROP_CURRENT_TIME, currentPosition / 1000D);
@@ -250,7 +255,7 @@ class VideoEventEmitter {
 
     void playbackRateChange(float rate) {
         WritableMap map = Arguments.createMap();
-        map.putDouble(EVENT_PROP_PLAYBACK_RATE, (double)rate);
+        map.putDouble(EVENT_PROP_PLAYBACK_RATE, (double) rate);
         receiveEvent(EVENT_PLAYBACK_RATE_CHANGE, map);
     }
 
@@ -262,18 +267,18 @@ class VideoEventEmitter {
         receiveEvent(EVENT_EPG_ICON_CLICK, null);
     }
 
-    public void statsIconClick() {
+    void statsIconClick() {
         receiveEvent(EVENT_STATS_ICON_CLICK, null);
     }
 
-    public void relatedVideoClick(int id, String type) {
+    void relatedVideoClick(int id, String type) {
         WritableMap map = Arguments.createMap();
         map.putInt(EVENT_PROP_RELATED_VIDEO_ID, id);
         map.putString(EVENT_PROP_RELATED_VIDEO_TYPE, type);
         receiveEvent(EVENT_RELATED_VIDEO_CLICKED, map);
     }
 
-    public void relatedVideosIconClicked() {
+    void relatedVideosIconClicked() {
         receiveEvent(EVENT_RELATED_VIDEOS_ICON_CLICKED, null);
     }
 
@@ -336,5 +341,11 @@ class VideoEventEmitter {
 
     private void receiveEvent(@VideoEvents String type, WritableMap event) {
         eventEmitter.receiveEvent(viewId, type, event);
+    }
+
+    void videoAboutToEnd(boolean isAboutToEnd) {
+        WritableMap map = Arguments.createMap();
+        map.putBoolean(EVENT_PROP_IS_ABOUT_TO_END, isAboutToEnd);
+        receiveEvent(EVENT_VIDEO_ABOUT_TO_END, map);
     }
 }

--- a/ios/Video/RCTVideo.h
+++ b/ios/Video/RCTVideo.h
@@ -36,6 +36,7 @@
 @property (nonatomic, copy) RCTBubblingEventBlock onPlaybackResume;
 @property (nonatomic, copy) RCTBubblingEventBlock onPlaybackRateChange;
 @property (nonatomic, copy) RCTBubblingEventBlock onRequireAdParameters;
+@property (nonatomic, copy) RCTBubblingEventBlock onVideoAboutToEnd;
 @property (nonatomic, strong) AVDorisPlayer *player;
 @property (nonatomic, strong) AVDoris *avdoris;
 

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -538,6 +538,15 @@ static int const RCTVideoUnset = -1;
                            @"target": self.reactTag,
                            @"seekableDuration": [self calculateSeekableDuration],
                            });
+      if (self.onVideoAboutToEnd) {
+          bool isAboutToEnd;
+          if (currentTimeSecs >= duration - 10) {
+              isAboutToEnd = YES;
+          } else {
+              isAboutToEnd = NO;
+          }
+          self.onVideoAboutToEnd(@{@"isAboutToEnd": [NSNumber numberWithBool:isAboutToEnd]});
+      }
   }
 }
 

--- a/ios/Video/RCTVideoManager.m
+++ b/ios/Video/RCTVideoManager.m
@@ -58,6 +58,7 @@ RCT_EXPORT_VIEW_PROPERTY(onPlaybackStalled, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onPlaybackResume, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onPlaybackRateChange, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onRequireAdParameters, RCTBubblingEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onVideoAboutToEnd, RCTBubblingEventBlock);
 
 RCT_EXPORT_METHOD(seekToTimestamp:(nonnull NSNumber *)node isoDate:(NSString *)isoDate) {
     [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *,UIView *> *viewRegistry) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.9.0",
+    "version": "5.10.0",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",

--- a/types/callbacks.ts
+++ b/types/callbacks.ts
@@ -14,5 +14,6 @@ export interface IVideoPlayerCallbacks {
   onPlaybackStalled?: (e: any) => void;
   onPlaybackResume?: (e: any) => void;
   onRelatedVideoClicked?: (e: any) => void;
+  onRelatedVideosIconClicked?: (e: any) => void;
   onVideoAboutToEnd?: (e: any) => void;
 }

--- a/types/callbacks.ts
+++ b/types/callbacks.ts
@@ -14,4 +14,5 @@ export interface IVideoPlayerCallbacks {
   onPlaybackStalled?: (e: any) => void;
   onPlaybackResume?: (e: any) => void;
   onRelatedVideoClicked?: (e: any) => void;
+  onVideoAboutToEnd?: (e: any) => void;
 }


### PR DESCRIPTION
## Description
Emit an `onVideoAboutToEnd` event from the player on each progress update to indicate to the JS layer whether the currently playing video is about to end soon (in less than 10 seconds) or not.

## To do
- [x] Make required iOS changes to emit `onVideoAboutToEnd` event
- [x] Make required Android changes to emit `onVideoAboutToEnd` event
- [x] Bump library version