### PR TITLE
Fix: Video player crashing on startup

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -431,7 +431,7 @@ class ReactTVExoplayerView extends FrameLayout
 
             playerInitTime = new Date().getTime();
 
-            Source source = new SourceBuilder(src.getUri(), src.getId())
+            source = new SourceBuilder(src.getUri(), src.getId())
                     .setTitle(src.getTitle())
                     .setIsLive(live)
                     .setMuxData(src.getMuxData(), exoDorisPlayerView.getVideoSurfaceView())

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.11.0",
+    "version": "5.11.1",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",


### PR DESCRIPTION
* Fixed a bug that would cause video player to crash on startup when trying to play IMA streams