### PR TITLE
Fix: DORIS-747 Ad tag parameters not being updated live

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/entity/RNImaSource.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/entity/RNImaSource.java
@@ -12,19 +12,30 @@ public class RNImaSource {
     private static final String KEY_VIDEO_ID = "videoId";
     private static final String KEY_AUTH_TOKEN = "authToken";
     private static final String KEY_AD_TAG_PARAMETERS = "adTagParameters";
+    private static final String KEY_START_DATE = "startDate";
+    private static final String KEY_END_DATE = "endDate";
 
     private final String assetKey;
     private final String contentSourceId;
     private final String videoId;
     private final String authToken;
-    private final Map<String, Object> adTagParameters;
+
+    private Map<String, Object> adTagParametersMap;
+    private double startDate;
+    private double endDate;
 
     public RNImaSource(@NonNull Map<String, Object> imaSource) {
         this.assetKey = (String) imaSource.get(KEY_ASSET_KEY);
         this.contentSourceId = (String) imaSource.get(KEY_CONTENT_SOURCE_ID);
         this.videoId = (String) imaSource.get(KEY_VIDEO_ID);
         this.authToken = (String) imaSource.get(KEY_AUTH_TOKEN);
-        this.adTagParameters = (Map<String, Object>) imaSource.get(KEY_AD_TAG_PARAMETERS);
+        this.adTagParametersMap = (Map<String, Object>) imaSource.get(KEY_AD_TAG_PARAMETERS);
+        this.startDate = imaSource.get(KEY_START_DATE) != null ?
+                         (double) imaSource.get(KEY_START_DATE) :
+                         Long.MIN_VALUE;
+        this.endDate = imaSource.get(KEY_END_DATE) != null ?
+                       (double) imaSource.get(KEY_END_DATE) :
+                       Long.MAX_VALUE;
     }
 
     @Nullable
@@ -48,7 +59,24 @@ public class RNImaSource {
     }
 
     @Nullable
-    public Map<String, Object> getAdTagParameters() {
-        return adTagParameters;
+    public Map<String, Object> getAdTagParametersMap() {
+        return adTagParametersMap;
+    }
+
+    public double getStartDate() {
+        return startDate;
+    }
+
+    public double getEndDate() {
+        return endDate;
+    }
+
+    public void replaceAdTagParameters(
+            Map<String, Object> adTagParameters,
+            double startDate,
+            double endDate) {
+        this.adTagParametersMap = adTagParameters;
+        this.startDate = startDate;
+        this.endDate = endDate;
     }
 }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -37,6 +37,7 @@ import com.brentvatne.entity.RelatedVideo;
 import com.brentvatne.react.R;
 import com.brentvatne.receiver.AudioBecomingNoisyReceiver;
 import com.brentvatne.receiver.BecomingNoisyListener;
+import com.brentvatne.util.AdTagParametersHelper;
 import com.brentvatne.util.ImdbGenreMap;
 import com.dice.shield.drm.entity.ActionToken;
 import com.diceplatform.doris.ExoDoris;
@@ -1806,5 +1807,24 @@ class ReactTVExoplayerView extends FrameLayout
     @Override
     public void onWatchListButtonClicked() {
         // Todo: Once the watchlist button has been implemented, fire an event here when user clicks it
+    }
+
+    public void replaceAdTagParameters(Map<String, Object> replaceAdTagParametersMap) {
+        if (replaceAdTagParametersMap == null || exoDorisImaWrapper == null) {
+            return;
+        }
+
+        double startDate = replaceAdTagParametersMap.get(KEY_START_DATE) != null ? (double) replaceAdTagParametersMap.get(KEY_START_DATE) : Long.MIN_VALUE;
+        double endDate = replaceAdTagParametersMap.get(KEY_END_DATE) != null ? (double) replaceAdTagParametersMap.get(KEY_END_DATE) : Long.MAX_VALUE;
+
+        if (imaSrc.getStartDate() != startDate || imaSrc.getEndDate() != endDate) {
+            Map<String, Object> adTagParametersMap = (Map<String, Object>) replaceAdTagParametersMap.get(KEY_AD_TAG_PARAMETERS);
+            AdTagParameters adTagParameters = AdTagParametersHelper.createAdTagParameters(getContext(), adTagParametersMap);
+            adTagParameters.setCustParams(adTagParameters.getCustParams() + "&pw=" + getWidth()
+                                                  + "&ph=" + getHeight());
+
+            imaSrc.replaceAdTagParameters(adTagParametersMap, startDate, endDate);
+            exoDorisImaWrapper.replaceAdTagParameters(adTagParameters, (long) startDate, (long) endDate);
+        }
     }
 }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -142,6 +142,8 @@ class ReactTVExoplayerView extends FrameLayout
     private static final int SHOW_JS_PROGRESS = 1;
     private static final int SHOW_NATIVE_PROGRESS = 2;
 
+    private static final String KEY_FIRST_CATEGORY = "first_category=";
+    private static final String KEY_RATING = "rating=";
     private static final String KEY_AD_TAG_PARAMETERS = "adTagParameters";
     private static final String KEY_START_DATE = "startDate";
     private static final String KEY_END_DATE = "endDate";
@@ -224,7 +226,7 @@ class ReactTVExoplayerView extends FrameLayout
                     long position = player.getCurrentPosition();
                     long bufferedDuration = player.getBufferedPercentage() * player.getDuration() / 100;
 
-                    if (src.isLive) {
+                    if (isLive) {
                         Timeline timeline = player.getCurrentTimeline();
                         if (!timeline.isEmpty()) {
                             position -= timeline.getPeriod(player.getCurrentPeriodIndex(), new Timeline.Period()).getPositionInWindowMs();
@@ -252,7 +254,7 @@ class ReactTVExoplayerView extends FrameLayout
                 if (player != null && player.getPlaybackState() == Player.STATE_READY && player.getPlayWhenReady()) {
                     long position = player.getCurrentPosition();
 
-                    if (src.isLive && isImaStream) {
+                    if (isLive && isImaStream) {
                         Timeline timeline = player.getCurrentTimeline();
                         if (!timeline.isEmpty()) {
                             long windowStartTimeMs = timeline.getWindow(player.getCurrentWindowIndex(), new Timeline.Window()).windowStartTimeMs;

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -259,7 +259,7 @@ class ReactTVExoplayerView extends FrameLayout
                             position = (windowStartTimeMs + position) / 1000L;
 
                             if (position < imaSrc.getStartDate() || position > imaSrc.getEndDate()) {
-                                eventEmitter.requireAdParameters((double) position);
+                                eventEmitter.requireAdParameters((double) position, false);
                             }
                         }
                     }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
@@ -106,6 +106,7 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
     private static final int COMMAND_SEEK_TO_NOW = 1;
     private static final int COMMAND_SEEK_TO_TIMESTAMP = 2;
     private static final int COMMAND_SEEK_TO_POSITION = 3;
+    private static final int COMMAND_REPLACE_AD_TAG_PARAMETERS = 4;
 
     private final ReactApplicationContext reactApplicationContext;
 
@@ -503,7 +504,9 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
                 "seekToTimestamp",
                 COMMAND_SEEK_TO_TIMESTAMP,
                 "seekToPosition",
-                COMMAND_SEEK_TO_POSITION
+                COMMAND_SEEK_TO_POSITION,
+                "replaceAdTagParameters",
+                COMMAND_REPLACE_AD_TAG_PARAMETERS
         );
     }
 
@@ -519,6 +522,9 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
                 break;
             case COMMAND_SEEK_TO_POSITION:
                 root.seekTo(args.getInt(0));
+                break;
+            case COMMAND_REPLACE_AD_TAG_PARAMETERS:
+                root.replaceAdTagParameters(args.getMap(0) != null ? args.getMap(0).toHashMap() : null);
                 break;
         }
     }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
@@ -106,7 +106,6 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
     private static final int COMMAND_SEEK_TO_NOW = 1;
     private static final int COMMAND_SEEK_TO_TIMESTAMP = 2;
     private static final int COMMAND_SEEK_TO_POSITION = 3;
-    private static final int COMMAND_REPLACE_AD_TAG_PARAMETERS = 4;
 
     private final ReactApplicationContext reactApplicationContext;
 
@@ -504,27 +503,23 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
                 "seekToTimestamp",
                 COMMAND_SEEK_TO_TIMESTAMP,
                 "seekToPosition",
-                COMMAND_SEEK_TO_POSITION,
-                "replaceAdTagParameters",
-                COMMAND_REPLACE_AD_TAG_PARAMETERS
+                COMMAND_SEEK_TO_POSITION
         );
     }
 
     @Override
-    public void receiveCommand(final RNDicePlayerView root, int commandId, @Nullable ReadableArray args) {
+    public void receiveCommand(final ReactTVExoplayerView root, int commandId, @Nullable ReadableArray args) {
         // This will be called whenever a command is sent from react-native.
         switch (commandId) {
             case COMMAND_SEEK_TO_NOW:
-                root.playerSeekTo(C.TIME_UNSET);
+                root.seekTo(C.TIME_UNSET);
                 break;
             case COMMAND_SEEK_TO_TIMESTAMP:
-                root.playerSeekTo(args.getString(0));
+                root.seekTo(args.getString(0));
                 break;
             case COMMAND_SEEK_TO_POSITION:
-                root.playerSeekTo(args.getInt(0));
+                root.seekTo(args.getInt(0));
                 break;
-            case COMMAND_REPLACE_AD_TAG_PARAMETERS:
-                root.replaceAdTagParameters(args.getMap(0) != null ? args.getMap(0).toHashMap() : null);
         }
     }
 }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
@@ -106,6 +106,7 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
     private static final int COMMAND_SEEK_TO_NOW = 1;
     private static final int COMMAND_SEEK_TO_TIMESTAMP = 2;
     private static final int COMMAND_SEEK_TO_POSITION = 3;
+    private static final int COMMAND_REPLACE_AD_TAG_PARAMETERS = 4;
 
     private final ReactApplicationContext reactApplicationContext;
 
@@ -503,23 +504,27 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
                 "seekToTimestamp",
                 COMMAND_SEEK_TO_TIMESTAMP,
                 "seekToPosition",
-                COMMAND_SEEK_TO_POSITION
+                COMMAND_SEEK_TO_POSITION,
+                "replaceAdTagParameters",
+                COMMAND_REPLACE_AD_TAG_PARAMETERS
         );
     }
 
     @Override
-    public void receiveCommand(final ReactTVExoplayerView root, int commandId, @Nullable ReadableArray args) {
+    public void receiveCommand(final RNDicePlayerView root, int commandId, @Nullable ReadableArray args) {
         // This will be called whenever a command is sent from react-native.
         switch (commandId) {
             case COMMAND_SEEK_TO_NOW:
-                root.seekTo(C.TIME_UNSET);
+                root.playerSeekTo(C.TIME_UNSET);
                 break;
             case COMMAND_SEEK_TO_TIMESTAMP:
-                root.seekTo(args.getString(0));
+                root.playerSeekTo(args.getString(0));
                 break;
             case COMMAND_SEEK_TO_POSITION:
-                root.seekTo(args.getInt(0));
+                root.playerSeekTo(args.getInt(0));
                 break;
+            case COMMAND_REPLACE_AD_TAG_PARAMETERS:
+                root.replaceAdTagParameters(args.getMap(0) != null ? args.getMap(0).toHashMap() : null);
         }
     }
 }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
@@ -155,6 +155,7 @@ class VideoEventEmitter {
     private static final String EVENT_PROP_TOUCH_ACTION_MOVE_DY = "dy";
     private static final String EVENT_PROP_IS_ABOUT_TO_END = "isAboutToEnd";
     private static final String EVENT_PROP_DATE = "date";
+    private static final String EVENT_PROP_IS_BLOCKING = "isBlocking";
 
     private static final String EVENT_PROP_ERROR = "error";
     private static final String EVENT_PROP_ERROR_STRING = "errorString";
@@ -360,9 +361,10 @@ class VideoEventEmitter {
         receiveEvent(EVENT_FAVOURITE_BUTTON_CLICK, null);
     }
 
-    void requireAdParameters(double date) {
+    void requireAdParameters(double date, boolean isBlocking) {
         WritableMap map = Arguments.createMap();
         map.putDouble(EVENT_PROP_DATE, date);
+        map.putBoolean(EVENT_PROP_IS_BLOCKING, isBlocking);
         receiveEvent(EVENT_REQUIRE_AD_PARAMETERS, map);
     }
 }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
@@ -37,6 +37,7 @@ class VideoEventEmitter {
     private static final String EVENT_FULLSCREEN_WILL_DISMISS = "onVideoFullscreenPlayerWillDismiss";
     private static final String EVENT_FULLSCREEN_DID_DISMISS = "onVideoFullscreenPlayerDidDismiss";
     private static final String EVENT_VIDEO_ABOUT_TO_END = "onVideoAboutToEnd";
+    private static final String EVENT_REQUIRE_AD_PARAMETERS = "onRequireAdParameters";
 
     private static final String EVENT_STALLED = "onPlaybackStalled";
     private static final String EVENT_RESUME = "onPlaybackResume";
@@ -86,7 +87,8 @@ class VideoEventEmitter {
             EVENT_RELATED_VIDEO_CLICKED,
             EVENT_RELATED_VIDEOS_ICON_CLICKED,
             EVENT_VIDEO_ABOUT_TO_END,
-            EVENT_FAVOURITE_BUTTON_CLICK
+            EVENT_FAVOURITE_BUTTON_CLICK,
+            EVENT_REQUIRE_AD_PARAMETERS
     };
 
     @Retention(RetentionPolicy.SOURCE)
@@ -119,7 +121,8 @@ class VideoEventEmitter {
                        EVENT_RELATED_VIDEO_CLICKED,
                        EVENT_RELATED_VIDEOS_ICON_CLICKED,
                        EVENT_VIDEO_ABOUT_TO_END,
-                       EVENT_FAVOURITE_BUTTON_CLICK
+                       EVENT_FAVOURITE_BUTTON_CLICK,
+                       EVENT_REQUIRE_AD_PARAMETERS
                })
     @interface VideoEvents {
     }
@@ -151,6 +154,7 @@ class VideoEventEmitter {
     private static final String EVENT_PROP_TOUCH_ACTION_MOVE_DX = "dx";
     private static final String EVENT_PROP_TOUCH_ACTION_MOVE_DY = "dy";
     private static final String EVENT_PROP_IS_ABOUT_TO_END = "isAboutToEnd";
+    private static final String EVENT_PROP_DATE = "date";
 
     private static final String EVENT_PROP_ERROR = "error";
     private static final String EVENT_PROP_ERROR_STRING = "errorString";
@@ -354,5 +358,11 @@ class VideoEventEmitter {
 
     void favouriteButtonClick() {
         receiveEvent(EVENT_FAVOURITE_BUTTON_CLICK, null);
+    }
+
+    void requireAdParameters(double date) {
+        WritableMap map = Arguments.createMap();
+        map.putDouble(EVENT_PROP_DATE, date);
+        receiveEvent(EVENT_REQUIRE_AD_PARAMETERS, map);
     }
 }

--- a/android-exoplayer/src/main/java/com/brentvatne/util/AdTagParametersHelper.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/util/AdTagParametersHelper.java
@@ -1,0 +1,57 @@
+package com.dice.video;
+
+import android.content.Context;
+
+import androidx.annotation.Nullable;
+
+import com.diceplatform.doris.ext.ima.entity.AdTagParameters;
+import com.diceplatform.doris.ext.ima.entity.AdTagParametersBuilder;
+
+import java.util.Map;
+
+final class AdTagParametersHelper {
+
+    private static final String KEY_IU = "iu";
+    private static final String KEY_CUST_PARAMS = "cust_params";
+    private static final String KEY_OUTPUT = "output";
+    private static final String KEY_VPA = "vpa";
+    private static final String KEY_AN = "an";
+    private static final String KEY_DESCRIPTION_URL = "description_url";
+    private static final String KEY_URL = "url";
+
+    // Prevents instantiation
+    private AdTagParametersHelper() {
+    }
+
+    @Nullable
+    static AdTagParameters createAdTagParameters(
+            Context context,
+            Map<String, Object> adTagParametersMap) {
+        if (adTagParametersMap == null || adTagParametersMap.isEmpty()) {
+            return null;
+        }
+
+        String iu = (String) adTagParametersMap.get(KEY_IU);
+        String custParams = (String) adTagParametersMap.get(KEY_CUST_PARAMS);
+        String output = (String) adTagParametersMap.get(KEY_OUTPUT);
+        String vpa = (String) adTagParametersMap.get(KEY_VPA);
+        String an = (String) adTagParametersMap.get(KEY_AN);
+        String descriptionUrl = (String) adTagParametersMap.get(KEY_DESCRIPTION_URL);
+        String url = (String) adTagParametersMap.get(KEY_URL);
+
+        String msid = context.getPackageName();
+        String isLat = "0"; // Todo: Remove this hard-coded value once we ask the user if they want to enable/disable limited ad tracking
+
+        return new AdTagParametersBuilder()
+                .setIu(iu)
+                .setCustParams(custParams)
+                .setOutput(output)
+                .setVpa(vpa)
+                .setMsid(msid)
+                .setAn(an)
+                .setIsLat(isLat)
+                .setDescriptionUrl(descriptionUrl)
+                .setUrl(url)
+                .build();
+    }
+}

--- a/android-exoplayer/src/main/java/com/brentvatne/util/AdTagParametersHelper.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/util/AdTagParametersHelper.java
@@ -9,7 +9,7 @@ import com.diceplatform.doris.ext.ima.entity.AdTagParametersBuilder;
 
 import java.util.Map;
 
-final class AdTagParametersHelper {
+public final class AdTagParametersHelper {
 
     private static final String KEY_IU = "iu";
     private static final String KEY_CUST_PARAMS = "cust_params";

--- a/android-exoplayer/src/main/java/com/brentvatne/util/AdTagParametersHelper.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/util/AdTagParametersHelper.java
@@ -1,4 +1,4 @@
-package com.dice.video;
+package com.brentvatne.util;
 
 import android.content.Context;
 

--- a/android-exoplayer/src/main/java/com/brentvatne/util/AdTagParametersHelper.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/util/AdTagParametersHelper.java
@@ -2,7 +2,7 @@ package com.brentvatne.util;
 
 import android.content.Context;
 
-import androidx.annotation.Nullable;
+import androidx.annotation.NonNull;
 
 import com.diceplatform.doris.ext.ima.entity.AdTagParameters;
 import com.diceplatform.doris.ext.ima.entity.AdTagParametersBuilder;
@@ -23,12 +23,12 @@ public final class AdTagParametersHelper {
     private AdTagParametersHelper() {
     }
 
-    @Nullable
-    static AdTagParameters createAdTagParameters(
+    @NonNull
+    public static AdTagParameters createAdTagParameters(
             Context context,
             Map<String, Object> adTagParametersMap) {
         if (adTagParametersMap == null || adTagParametersMap.isEmpty()) {
-            return null;
+            return new AdTagParametersBuilder().build();
         }
 
         String iu = (String) adTagParametersMap.get(KEY_IU);

--- a/android-exoplayer/src/main/java/com/brentvatne/util/ImdbGenreMap.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/util/ImdbGenreMap.java
@@ -50,7 +50,7 @@ public final class ImdbGenreMap {
             .put("realityshow", "Reality-TV")
             .put("religious", "Drama")
             .put("romance", "Romance")
-            .put("sci-fi", "Sci-Fi")
+            .put("scifi", "Sci-Fi")
             .put("soccer", "Sport")
             .put("special", "Drama")
             .put("sports", "Sport")

--- a/android-exoplayer/src/main/java/com/brentvatne/util/ImdbGenreMap.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/util/ImdbGenreMap.java
@@ -50,6 +50,7 @@ public final class ImdbGenreMap {
             .put("realityshow", "Reality-TV")
             .put("religious", "Drama")
             .put("romance", "Romance")
+            .put("sci-fi", "Sci-Fi")
             .put("scifi", "Sci-Fi")
             .put("soccer", "Sport")
             .put("special", "Drama")

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.16.1",
+    "version": "5.17.0",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",

--- a/types/ima.ts
+++ b/types/ima.ts
@@ -16,4 +16,5 @@ export interface IVideoReplaceAdTagParametersPayload {
 
 export interface IVideoPlayerOnRequireAdParametersPayload {
   date: number;
+  isBlocking: boolean;
 }


### PR DESCRIPTION
## Description
Fix ad tags not being updated correctly for live streams on Android TV and Fire TV.

## To Do
- [x] Fix `onRequireAdParameters` event not being emitted
- [x] Fix `replaceAdTagParameters` not being called.
- [x] Bump library version

## JIRA
[DORIS-747](https://dicetech.atlassian.net/browse/DORIS-747)