### PR TITLE
Fix/DEV-3255 Rewind and Fast Forward buttons appear briefly during live

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/entity/RNSource.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/entity/RNSource.java
@@ -12,7 +12,7 @@ import java.util.Map;
 
 public class RNSource {
 
-    private Uri uri;
+    private String url;
     private String extension;
 
     private final String id;
@@ -29,7 +29,7 @@ public class RNSource {
     private final String locale;
 
     public RNSource(
-            @NonNull Uri uri,
+            @NonNull String url,
             @NonNull String id,
             @Nullable String extension,
             @Nullable String title,
@@ -43,7 +43,7 @@ public class RNSource {
             @Nullable String channelLogoUrl,
             @Nullable String selectedAudioTrack,
             @Nullable String locale) {
-        this.uri = uri;
+        this.url = url;
         this.id = id;
         this.extension = extension;
         this.title = title;
@@ -60,12 +60,12 @@ public class RNSource {
     }
 
     @NonNull
-    public Uri getUri() {
-        return uri;
+    public String getUrl() {
+        return url;
     }
 
-    public void setUri(Uri uri) {
-        this.uri = uri;
+    public void setUrl(String url) {
+        this.url = url;
     }
 
     @NonNull

--- a/android-exoplayer/src/main/java/com/brentvatne/entity/RNSource.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/entity/RNSource.java
@@ -68,6 +68,10 @@ public class RNSource {
         this.url = url;
     }
 
+    public void setUri(Uri uri) {
+        this.url = uri.getPath();
+    }
+
     @NonNull
     public String getId() {
         return id;

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -1091,7 +1091,7 @@ class ReactTVExoplayerView extends FrameLayout
 
     @Override
     public void onTimelineChanged(Timeline timeline, int reason) {
-        if (reason == Player.TIMELINE_CHANGE_REASON_PREPARED && isLive) {
+        if (reason == Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED && isLive) {
             canSeekToLiveEdge = true;
         }
     }
@@ -1213,10 +1213,10 @@ class ReactTVExoplayerView extends FrameLayout
             int duration,
             String channelName,
             boolean apsTestFlag) {
-            if (url != null) {
-                String srcUrl = src != null ? src.getUrl() : null;
-                boolean isOriginalSourceNull = srcUrl == null;
-                boolean isSourceEqual = url.equals(srcUrl);
+        if (url != null) {
+            String srcUrl = src != null ? src.getUrl() : null;
+            boolean isOriginalSourceNull = srcUrl == null;
+            boolean isSourceEqual = url.equals(srcUrl);
 
             if (ima != null && !ima.isEmpty()) {
                 this.isImaStream = true;

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -416,7 +416,7 @@ class ReactTVExoplayerView extends FrameLayout
 
             activateMediaSession();
         }
-        if (playerNeedsSource && src.getUri() != null) {
+        if (playerNeedsSource && src.getUrl() != null) {
             boolean haveResumePosition = resumeWindow != C.INDEX_UNSET;
             boolean shouldSeekOnInit = shouldSeekTo > C.TIME_UNSET;
             if (haveResumePosition && !force) {
@@ -431,7 +431,7 @@ class ReactTVExoplayerView extends FrameLayout
 
             playerInitTime = new Date().getTime();
 
-            source = new SourceBuilder(src.getUri(), src.getId())
+            source = new SourceBuilder(src.getUrl(), src.getId())
                     .setTitle(src.getTitle())
                     .setIsLive(live)
                     .setMuxData(src.getMuxData(), exoDorisPlayerView.getVideoSurfaceView())
@@ -442,12 +442,12 @@ class ReactTVExoplayerView extends FrameLayout
                 loadImaStream();
             } else if (actionToken != null) {
                 try {
-                    player.load(source, !haveResumePosition, force, actionToken);
+                    player.load(source, !haveResumePosition, actionToken);
                 } catch (UnsupportedDrmException e) {
                     handleDrmError(e);
                 }
             } else {
-                player.load(source, !haveResumePosition, force);
+                player.load(source, !haveResumePosition);
             }
 
             playerNeedsSource = false;
@@ -749,9 +749,9 @@ class ReactTVExoplayerView extends FrameLayout
     }
 
     @Override
-    public void onPlayerStateChanged(boolean playWhenReady, int playbackState) {
-        String text = "onStateChanged: playWhenReady=" + playWhenReady + ", playbackState=";
-        switch (playbackState) {
+    public void onPlaybackStateChanged(int state) {
+        String text = "onStateChanged: playbackState = " + state;
+        switch (state) {
             case Player.STATE_IDLE:
                 text += "idle";
                 eventEmitter.idle();
@@ -951,8 +951,8 @@ class ReactTVExoplayerView extends FrameLayout
     }
 
     @Override
-    public void onTimelineChanged(Timeline timeline, Object manifest, int reason) {
-        if (reason == Player.TIMELINE_CHANGE_REASON_PREPARED && live) {
+    public void onTimelineChanged(Timeline timeline, int reason) {
+        if (reason == Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED && live) {
             canSeekToLiveEdge = true;
         }
     }
@@ -1054,7 +1054,7 @@ class ReactTVExoplayerView extends FrameLayout
     // ReactExoplayerViewManager public api
 
     public void setSrc(
-            Uri uri,
+            String url,
             String id,
             String extension,
             String title,
@@ -1067,10 +1067,10 @@ class ReactTVExoplayerView extends FrameLayout
             String thumbnailUrl,
             String channelLogoUrl,
             Map<String, Object> ima) {
-        if (uri != null) {
-            Uri srcUri = src != null ? src.getUri() : null;
-            boolean isOriginalSourceNull = srcUri == null;
-            boolean isSourceEqual = uri.equals(srcUri);
+        if (url != null) {
+            String srcUrl = src != null ? src.getUrl() : null;
+            boolean isOriginalSourceNull = srcUrl == null;
+            boolean isSourceEqual = url.equals(srcUrl);
 
             if (ima != null && !ima.isEmpty()) {
                 this.isImaStream = true;
@@ -1080,7 +1080,7 @@ class ReactTVExoplayerView extends FrameLayout
             }
 
             this.src = new RNSource(
-                    uri,
+                    url,
                     id,
                     extension,
                     title,
@@ -1110,8 +1110,8 @@ class ReactTVExoplayerView extends FrameLayout
 
     public void setRawSrc(@NonNull final Uri uri, @Nullable final String extension) {
         if (uri != null) {
-            boolean isOriginalSourceNull = src.getUri() == null;
-            boolean isSourceEqual = uri.equals(src.getUri());
+            boolean isOriginalSourceNull = src.getUrl() == null;
+            boolean isSourceEqual = uri.equals(src.getUrl());
 
             this.src.setUri(uri);
             this.src.setExtension(extension);

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
@@ -192,29 +192,27 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
         if (startsWithValidScheme(uriString)) {
             ActionToken actionToken = ActionToken.fromJson(drm);
 
-            if (srcUri != null) {
-                videoView.setSrc(
-                        uriString,
-                        id,
-                        extension,
-                        title,
-                        description,
-                        type,
-                        textTracks,
-                        actionToken,
-                        headers,
-                        muxData != null ? muxData.toHashMap() : null,
-                        thumbnailUrl,
-                        channelLogoUrl,
-                        ima != null ? ima.toHashMap() : null,
-                        channelId,
-                        seriesId,
-                        seasonId,
-                        playlistId,
-                        duration != null ? Integer.parseInt(duration) : 0,
-                        channelName,
-                        apsTestMode);
-            }
+            videoView.setSrc(
+                    uriString,
+                    id,
+                    extension,
+                    title,
+                    description,
+                    type,
+                    textTracks,
+                    actionToken,
+                    headers,
+                    muxData != null ? muxData.toHashMap() : null,
+                    thumbnailUrl,
+                    channelLogoUrl,
+                    ima != null ? ima.toHashMap() : null,
+                    channelId,
+                    seriesId,
+                    seasonId,
+                    playlistId,
+                    duration != null ? Integer.parseInt(duration) : 0,
+                    channelName,
+                    apsTestMode);
         } else {
             int identifier = context.getResources().getIdentifier(
                     uriString,

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
@@ -174,22 +174,19 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
         if (startsWithValidScheme(uriString)) {
             ActionToken actionToken = ActionToken.fromJson(drm);
 
-            if (uriString != null) {
-                videoView.setSrc(
-                        uriString,
-                        id,
-                        extension,
-                        title,
-                        description,
-                        type,
-                        textTracks,
-                        actionToken,
-                        headers,
-                        muxData != null ? muxData.toHashMap() : null,
-                        thumbnailUrl,
-                        channelLogoUrl,
-                        ima != null ? ima.toHashMap() : null);
-            }
+            videoView.setSrc(uriString,
+                             id,
+                             extension,
+                             title,
+                             description,
+                             type,
+                             textTracks,
+                             actionToken,
+                             headers,
+                             muxData != null ? muxData.toHashMap() : null,
+                             thumbnailUrl,
+                             channelLogoUrl,
+                             ima != null ? ima.toHashMap() : null);
         } else {
             int identifier = context.getResources().getIdentifier(
                     uriString,
@@ -429,6 +426,10 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
     }
 
     private boolean startsWithValidScheme(String uriString) {
+        if (uriString == null) {
+            return false;
+        }
+
         return uriString.startsWith("http://")
                 || uriString.startsWith("https://")
                 || uriString.startsWith("content://")

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
@@ -172,12 +172,11 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
         }
 
         if (startsWithValidScheme(uriString)) {
-            Uri srcUri = Uri.parse(uriString);
             ActionToken actionToken = ActionToken.fromJson(drm);
 
-            if (srcUri != null) {
+            if (uriString != null) {
                 videoView.setSrc(
-                        srcUri,
+                        uriString,
                         id,
                         extension,
                         title,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.14.1",
+    "version": "5.15.0",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",


### PR DESCRIPTION
## Description
When viewing live content on Prende TV, the fast forward and rewind icons appears briefly. They should not be displayed during live content. They should only be displayed for VOD content.

## To Do
- [x] Fix bug where fast forward and rewind buttons would appear briefly during live content playback (This fix was achieved by migrating to ExoPlayer 2.12.3)
- [x] Bump library version

## JIRA
[DEV-3255](https://dicetech.atlassian.net/browse/DEV-3255)