### PR TITLE
Fix/DEV-3301 Play/pause button displayed during live playback

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -1811,6 +1811,11 @@ class ReactTVExoplayerView extends FrameLayout
         // Todo: Once the watchlist button has been implemented, fire an event here when user clicks it
     }
 
+    @Override
+    public void onEpgButtonClicked() {
+        eventEmitter.epgIconClick();
+    }
+
     public void replaceAdTagParameters(Map<String, Object> replaceAdTagParametersMap) {
         if (replaceAdTagParametersMap == null || exoDorisImaWrapper == null) {
             return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.19.0",
+    "version": "5.19.1",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",


### PR DESCRIPTION
## Description
Hide the play/pause button when watching a live stream without a DVR window

## To Do
- [x] Make react-native-video compatible with the latest changes to ExoDoris by adding `onEpgButtonClicked` method
- [x] Bump library version

## JIRA
[DEV-3301](https://dicetech.atlassian.net/browse/DEV-3301)

## Screenshot
![Screenshot_1614181836](https://user-images.githubusercontent.com/5672768/109027005-41818780-76b8-11eb-942b-0bab6df550c4.png)