### PR TITLE
Fix/DEV-3247 Resume from Alexa interruptions

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -418,13 +418,9 @@ class ReactTVExoplayerView extends FrameLayout
             if (isLive) {
                 // always seek to live edge when returning from background to a live event
                 canSeekToLiveEdge = true;
-                setPausedModifier(false);
-                setPlayWhenReady(true);
-            } else {
-                // otherwise whatever abide by what the previous user action was
-                setPausedModifier(isPaused);
-                setPlayWhenReady(!isPaused);
+                player.seekToDefaultPosition();
             }
+            player.play();
             fromBackground = true;
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.19.3",
+    "version": "5.19.4",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",


### PR DESCRIPTION
## Description
Currently playback is not resuming correctly after an Alexa interruption and the player goes into a strange state where playback is paused and the user can't use the playback controls to resume playback.

## To Do
- [x] Resume video playback when returning from an Alexa interruption
- [x] Bump library version

## JIRA
[DEV-2347](https://dicetech.atlassian.net/browse/DEV-3247)