### PR TITLE
Fix/DEV-3248 Continue video playback not working

### DIFF
--- a/Video.tsx
+++ b/Video.tsx
@@ -147,7 +147,7 @@ export default class Video extends React.PureComponent<IVideoPlayer, IState> {
     if (time !== 'now') {
       command =
         typeof time === 'string' ? SeekToCommand.SEEK_TO_TIMESTAMP : SeekToCommand.SEEK_TO_POSITION;
-      args.push(time as string);
+        args.push(time);
     }
 
     if (this.refPlayer) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
@@ -524,7 +524,7 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
                 root.seekTo(args.getString(0));
                 break;
             case COMMAND_SEEK_TO_POSITION:
-                root.seekTo(args.getInt(0));
+                root.seekTo(args.getInt(0) * 1000);
                 break;
             case COMMAND_REPLACE_AD_TAG_PARAMETERS:
                 root.replaceAdTagParameters(args.getMap(0) != null ? args.getMap(0).toHashMap() : null);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.19.4",
+    "version": "5.19.5",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",


### PR DESCRIPTION
## Description
Video playback does not currently resume from the previous position when continue button is pressed.

## To do
- [x] Set `initialWindowIndex` and `initialPositionIndex` properties in Source loaded by the player.
- [x] Bump `react-native-video` version

## JIRA
[DEV-3248](https://dicetech.atlassian.net/browse/DEV-3248)