### PR TITLE
Fix/DEV-3341 Mini player showing controls after ad

### DIFF
--- a/Video.tsx
+++ b/Video.tsx
@@ -142,7 +142,7 @@ export default class Video extends React.PureComponent<IVideoPlayer, IState> {
    */
   seekTo = (time: 'now' | string | number) => {
     let command = SeekToCommand.SEEK_TO_NOW;
-    let args: Array<string | number> = [];
+    const args: Array<string | number> = [];
 
     if (time !== 'now') {
       command =

--- a/Video.tsx
+++ b/Video.tsx
@@ -142,7 +142,7 @@ export default class Video extends React.PureComponent<IVideoPlayer, IState> {
    */
   seekTo = (time: 'now' | string | number) => {
     let command = SeekToCommand.SEEK_TO_NOW;
-    const args: string[] = [];
+    let args: Array<string | number> = [];
 
     if (time !== 'now') {
       command =

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -1776,7 +1776,9 @@ class ReactTVExoplayerView extends FrameLayout
         }
 
         if (adEvent.getType() == AD_BREAK_ENDED) {
-            setControls(true);
+            if (areControlsVisible) {
+                setControls(true);
+            }
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.19.8",
+    "version": "5.19.9",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.19.9",
+    "version": "5.19.10",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",


### PR DESCRIPTION
## Description
The mini player on the EPG is showing the playback controls and allowing the user to interact with them, right after ads have finished playing. The mini player should never show playback controls.

## To do
- [x] Only show playback controls after ads if `areControlsVisible` is true
- [x] Bump `react-native-video` version

## JIRA
[DEV-3341](https://dicetech.atlassian.net/browse/DEV-3341)