### PR TITLE
Fix/DEV-3381: Audio continues playing in background

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -412,7 +412,7 @@ class ReactTVExoplayerView extends FrameLayout
 
     @Override
     public void onHostResume() {
-        if (isInBackground) {
+        if (isInBackground && player != null) {
             Log.d(TAG, "onHostResume() isPaused: " + isPaused + " live: " + isLive);
             isInBackground = false; // reset to false first
             if (isLive) {
@@ -420,7 +420,7 @@ class ReactTVExoplayerView extends FrameLayout
                 canSeekToLiveEdge = true;
                 player.seekToDefaultPosition();
             }
-            player.play();
+            setPlayWhenReady(true);
             fromBackground = true;
         }
     }
@@ -430,8 +430,13 @@ class ReactTVExoplayerView extends FrameLayout
         Log.d(TAG, "onHostPause()");
         setPlayInBackground(false);
         setPlayWhenReady(false);
+        player.pause();
         onStopPlayback();
         isInBackground = true;
+
+        if (!isInteractive()) {
+            stopPlayback();
+        }
     }
 
     @Override
@@ -722,6 +727,7 @@ class ReactTVExoplayerView extends FrameLayout
         releaseMediaSession();
         adTagParameters = null;
         isImaStreamLoaded = false;
+        isInBackground = false;
 
         if (player != null) {
             updateResumePosition();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.19.10",
+    "version": "5.19.11",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",


### PR DESCRIPTION
## Description
When backgrounding the app the audio of the video continues playing in the background.

## To do
- [x] Prevent audio from playing in the background by stopping the player if it is no longer visible
- [x] Bump `react-native-video` version

## JIRA
[DEV-3341](https://dicetech.atlassian.net/browse/DEV-3341)