### PR TITLE
Fix/DEV-3382 Fast forward and rewind on Amazon remote issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.19.11",
+    "version": "5.19.12",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "eslint-plugin-react": "3.16.1"
     },
     "dependencies": {
-        "@imggaming/dice-shield": "git+ssh://git@github.com:DiceTechnology/dice-shield.git#semver:=2.3.1",
+        "@imggaming/dice-shield": "git+ssh://git@github.com:DiceTechnology/dice-shield.git#semver:=2.9.1",
         "keymirror": "0.1.1",
         "prop-types": "^15.5.10"
     },


### PR DESCRIPTION
## Description
Currently, fast forward and rewind does not work for IMA streams.

## To do
- [x] Bump Dice Shield version
- [x] Bump `react-native-video` version

## JIRA
[DEV-3382](https://dicetech.atlassian.net/browse/DEV-3382)