### PR TITLE
Fix/DEV-3402: Unable to use remote after ads

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -50,7 +50,6 @@ import com.diceplatform.doris.ext.ima.ExoDorisImaPlayer;
 import com.diceplatform.doris.ext.ima.ExoDorisImaWrapper;
 import com.diceplatform.doris.ext.ima.entity.AdInfo;
 import com.diceplatform.doris.ext.ima.entity.AdTagParameters;
-import com.diceplatform.doris.ext.ima.entity.AdTagParametersBuilder;
 import com.diceplatform.doris.ext.ima.entity.ImaLanguage;
 import com.diceplatform.doris.ext.ima.entity.ImaSource;
 import com.diceplatform.doris.ext.ima.entity.ImaSourceBuilder;
@@ -173,11 +172,12 @@ class ReactTVExoplayerView extends FrameLayout
     private boolean isBuffering;
     private boolean isMediaKeysEnabled = true;
     private boolean areControlsVisible = true;
+    private boolean areControlsAllowed = true;
     private long shouldSeekTo = C.TIME_UNSET;
     private float rate = 1f;
     private boolean isImaStream = false;
     private boolean isImaStreamLoaded = false;
-    private boolean isAmazonFireTv = false;
+    private boolean isAmazonFireTv;
     private int viewWidth;
     private int viewHeight;
 
@@ -1537,6 +1537,11 @@ class ReactTVExoplayerView extends FrameLayout
         this.hasStats = hasStats;
     }
 
+    public void setAreControlsAllowed(boolean allowed) {
+        areControlsAllowed = allowed;
+        setControls(allowed);
+    }
+
     public void setControls(final boolean visible) {
         areControlsVisible = visible;
         if (visible) {
@@ -1772,12 +1777,14 @@ class ReactTVExoplayerView extends FrameLayout
     @Override
     public void onAdEvent(AdEvent adEvent) {
         if (adEvent.getType() == AD_BREAK_STARTED) {
-            setControls(false);
+            if (areControlsAllowed) {
+                setControls(false);
+            }
             return;
         }
 
         if (adEvent.getType() == AD_BREAK_ENDED) {
-            if (areControlsVisible) {
+            if (areControlsAllowed) {
                 setControls(true);
             }
         }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
@@ -357,7 +357,7 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
 
     @ReactProp(name = PROP_CONTROLS)
     public void setControls(final ReactTVExoplayerView videoView, final boolean visible) {
-        videoView.setControls(visible);
+        videoView.setAreControlsAllowed(visible);
     }
 
     @ReactProp(name = PROP_CONTROLS_OPACITY)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.19.14",
+    "version": "5.19.15",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",


### PR DESCRIPTION
## Description
After an ad break has completed, the user is no longer able to access the playback controls.

## To do
- [x] Allow the user to access the playback controls after an ad break
- [x] Bump `react-native-video` version

## JIRA
[DEV-3402](https://dicetech.atlassian.net/browse/DEV-3402)