### PR TITLE
Fix/DEV-3415: Resume playback correctly when returning from background

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -433,7 +433,7 @@ class ReactTVExoplayerView extends FrameLayout
         setPlayWhenReady(false);
         player.pause();
         onStopPlayback();
-        isInBackground = true;
+        isInBackground = isInteractive();
 
         if (!isInteractive()) {
             stopPlayback();

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -434,11 +434,8 @@ class ReactTVExoplayerView extends FrameLayout
         player.pause();
         onStopPlayback();
         isInBackground = isInteractive();
-
-        if (!isInteractive()) {
-            stopPlayback();
-        }
     }
+
 
     @Override
     public void onHostDestroy() {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -436,7 +436,6 @@ class ReactTVExoplayerView extends FrameLayout
         isInBackground = isInteractive();
     }
 
-
     @Override
     public void onHostDestroy() {
         stopPlayback();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.19.18",
+    "version": "5.19.19",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",


### PR DESCRIPTION
## Description
On Fire TV, the player does not resume playback correctly when returning from a backgrounded state.

## To Do
- [x] Fix player not resuming playback correctly from a background state
- [x] Bump library version

## JIRA
[DEV-3415](https://dicetech.atlassian.net/browse/DEV-3415)