### PR TITLE
Fix/dev 3415 handle 403 from ads

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -51,6 +51,7 @@ import com.diceplatform.doris.entity.SourceBuilder;
 import com.diceplatform.doris.entity.TextTrack;
 import com.diceplatform.doris.ext.ima.ExoDorisImaPlayer;
 import com.diceplatform.doris.ext.ima.ExoDorisImaWrapper;
+import com.diceplatform.doris.ext.ima.ExoDorisImaWrapperListener;
 import com.diceplatform.doris.ext.ima.entity.AdInfo;
 import com.diceplatform.doris.ext.ima.entity.AdTagParameters;
 import com.diceplatform.doris.ext.ima.entity.ImaLanguage;
@@ -120,9 +121,8 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
         BecomingNoisyListener,
         AudioManager.OnAudioFocusChangeListener,
         MetadataOutput,
-        AdEvent.AdEventListener,
-        AdErrorEvent.AdErrorListener,
-        ExoDorisPlayerViewListener {
+        ExoDorisPlayerViewListener,
+        ExoDorisImaWrapperListener {
 
     private static final String TAG = "ReactTvExoplayerView";
     private static final String AMAZON_FEATURE_FIRE_TV = "amazon.hardware.fire_tv";
@@ -476,6 +476,7 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
                         exoDorisImaPlayer,
                         exoDorisPlayerView.getAdViewGroup(),
                         ImaLanguage.SPANISH_UNITED_STATES);
+                exoDorisImaWrapper.setExoDorisImaWrapperListener(this);
                 player = exoDorisImaPlayer.getExoDoris();
                 trackSelector = exoDorisImaPlayer.getTrackSelector();
             } else {
@@ -915,9 +916,6 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
                     AdInfo adInfo = exoDorisImaWrapper.getAdInfo();
                     exoDorisPlayerView.setExtraAdGroupMarkers(adInfo.getAdGroupTimesMs(),
                             adInfo.getPlayedAdGroups());
-
-                    exoDorisImaWrapper.addAdEventListener(this);
-                    exoDorisImaWrapper.addAdErrorListener(this);
 
                     Log.d(TAG, "IMA Stream ID = " + exoDorisImaWrapper.getStreamId());
                 }
@@ -1819,11 +1817,20 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
     @Override
     public void onAdError(AdErrorEvent adErrorEvent) {
         AdError error = adErrorEvent.getError();
-        eventEmitter.error(error.getMessage(), error);
+        if (!hasReloadedCurrentSource && isUnauthorizedAdError(error)) {
+            hasReloadedCurrentSource = true;
+            eventEmitter.reloadCurrentSource(src.getId(), metadata.getType());
+        } else {
+            eventEmitter.error(error.getMessage(), error);
+        }
 
         // Reset imaSrc and isImaStream to allow a new source to be loaded
         imaSrc = null;
-        this.isImaStream = false;
+        isImaStream = false;
+    }
+
+    private boolean isUnauthorizedAdError(AdError error) {
+        return error.getMessage().contains("HTTP status code: 403");
     }
 
     @Override
@@ -1872,5 +1879,10 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
             imaSrc.replaceAdTagParameters(adTagParametersMap, startDate, endDate);
             exoDorisImaWrapper.replaceAdTagParameters(adTagParameters, (long) startDate, (long) endDate);
         }
+    }
+
+    @Override
+    public void onRequireAdTagParameters(long seekPosition) {
+        eventEmitter.requireAdParameters((double) seekPosition, true);
     }
 }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -181,7 +181,7 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
     private boolean isAmazonFireTv;
     private int viewWidth = 0;
     private int viewHeight = 0;
-    private int unauthorizedExceptionCount = 0;
+    private boolean hasReloadedCurrentSource = false;
 
     // Props from React
     private RNSource src;
@@ -909,6 +909,8 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
                 exoDorisPlayerView.setFocusableInTouchMode(true);
                 exoDorisPlayerView.requestFocus();
 
+                hasReloadedCurrentSource = false;
+
                 if (isImaStream) {
                     AdInfo adInfo = exoDorisImaWrapper.getAdInfo();
                     exoDorisPlayerView.setExtraAdGroupMarkers(adInfo.getAdGroupTimesMs(),
@@ -1131,8 +1133,8 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
         if (isBehindLiveWindow(e)) {
             clearResumePosition();
             initializePlayer(false);
-        } else if (unauthorizedExceptionCount < 1 && isUnauthorizedException(e)) {
-            unauthorizedExceptionCount++;
+        } else if (!hasReloadedCurrentSource && isUnauthorizedException(e)) {
+            hasReloadedCurrentSource = true;
             eventEmitter.reloadCurrentSource(src.getId(), metadata.getType());
         } else if (e.type == ExoPlaybackException.TYPE_RENDERER) {
             Exception cause = e.getRendererException();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.20.0",
+    "version": "5.20.1",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",


### PR DESCRIPTION
## Description
Attempt to reload the current source programmatically once after getting an ad error `403`. If that reload fails, bubble the error up to the JS layer.

## To Do
- [x] Add `onReloadCurrentSource` event
- [x] Attempt to reload current source once after receiving an ad error `403`, thereafter bubble the error to JS layer
- [x] Bump library version

## JIRA
[DEV-3415](https://dicetech.atlassian.net/browse/DEV-3415)