### PR TITLE
Fix/DEV-3440: Fix play and pause during sleep

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -424,6 +424,7 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
                 canSeekToLiveEdge = true;
                 player.seekToDefaultPosition();
             }
+            activateMediaSession();
             setPlayWhenReady(true);
             fromBackground = true;
         }
@@ -438,6 +439,7 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
         updateResumePosition();
         onStopPlayback();
         isInBackground = isInteractive();
+        deactivateMediaSession();
     }
 
     @Override

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.20.2",
+    "version": "5.20.3",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",


### PR DESCRIPTION
## Description
Currently, after device has been put into sleep mode, the user is able to play and pause background audio using the Fire TV remote. Our app should never play audio in the background.

## To Do
- [x] Add `deactivateMediaSession()` to `onHostPause()` to prevent the user from controlling the player with the remote when our app is in the background.
- [x] Bump library version

## JIRA
[DEV-3440](https://dicetech.atlassian.net/browse/DEV-3440)