### PR TITLE
Fix: Resume playback after putting the app in the background

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -486,6 +486,12 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
                 trackSelector = player.getTrackSelector();
             }
 
+            AudioAttributes audioAttributes = new AudioAttributes.Builder()
+                    .setUsage(C.USAGE_MEDIA)
+                    .setContentType(C.CONTENT_TYPE_MOVIE)
+                    .build();
+
+            player.setAudioAttributes(audioAttributes, false);
             player.addListener(this);
             player.addMetadataOutput(this);
             exoDorisPlayerView.setPlayer(player);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.20.6",
+    "version": "5.20.7",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",


### PR DESCRIPTION
## Description
Currently, when resuming from background the video is paused. The video should continue playing when resuming from background.

## To Do
- [x] Set ExoPlayer to no longer play/pause on audio focus events
- [x] Bump library version