### PR TITLE
Fix/DEV-3520: Fast forward and rewind button focus

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -917,7 +917,6 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
 
                 exoDorisPlayerView.setFocusable(true);
                 exoDorisPlayerView.setFocusableInTouchMode(true);
-                exoDorisPlayerView.requestFocus();
 
                 hasReloadedCurrentSource = false;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.20.13",
+    "version": "5.20.14",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",


### PR DESCRIPTION
## Description
On Android TV and Fire TV, we currently lose focus of the fast forward and rewind buttons after clicking them. Making the fast forward and rewind experience quite bad.

## To do
- [x] Don't request focus to the player controls when playback state is PLAYER_READY
- [x] Bump `react-native-video` version

## JIRA
[DEV-3520](https://dicetech.atlassian.net/browse/DEV-3520)