### PR TITLE
Chore/|DEV-3567: Use correct player names in Mux

### DIFF
--- a/ios/Video/RCTVideo1.m
+++ b/ios/Video/RCTVideo1.m
@@ -25,6 +25,7 @@ static NSString *const playerVersion = @"react-native-video/3.3.1";
     NSDictionary* _Nullable _theme;
     NSDictionary* _Nullable _translations;
     NSDictionary* _Nullable _relatedVideos;
+    NSString* _playerName;
     
     SubtitleResourceLoaderDelegate* _delegate;
     dispatch_queue_t delegateQueue;
@@ -40,6 +41,7 @@ static NSString *const playerVersion = @"react-native-video/3.3.1";
     if ((self = [super init])) {
         _diceBeaconRequestOngoing = NO;
         _controls = YES;
+        _playerName = @"DicePlayer";
     }
     
     return self;
@@ -460,7 +462,7 @@ static NSString *const playerVersion = @"react-native-video/3.3.1";
 #pragma mark - Lifecycle
 - (void)dealloc {
     if (_playerData || _videoData) {
-        [MUXSDKStats destroyPlayer:@"dicePlayer"];
+        [MUXSDKStats destroyPlayer:_playerName];
         _playerData = nil;
         _videoData = nil;
     }
@@ -641,7 +643,11 @@ static NSString *const playerVersion = @"react-native-video/3.3.1";
                 
                 [_playerData setPlayerVersion:playerVersion];
                 
-                [_playerData setPlayerName:@"react-native-video/dice"];
+                value = [self stringFromDict:muxDict forKey:@"playerName"];
+                if (value) {
+                    _playerName = value;
+                }
+                [_playerData setPlayerName:_playerName];
                 
                 value = [self stringFromDict:muxDict forKey:@"subPropertyId"];
                 [_playerData setSubPropertyId:value];
@@ -684,8 +690,13 @@ static NSString *const playerVersion = @"react-native-video/3.3.1";
             [_videoData setVideoStreamType:value];
             
             
+            value = [self stringFromDict:muxDict forKey:@"playerName"];
+            if (value) {
+                _playerName = value;
+            }
+            
             if (isReplace) {
-                [MUXSDKStats videoChangeForPlayer:@"dicePlayer" withVideoData:_videoData];
+                [MUXSDKStats videoChangeForPlayer:_playerName withVideoData:_videoData];
             } else {
                 [self setupMux];
             }
@@ -701,9 +712,9 @@ static NSString *const playerVersion = @"react-native-video/3.3.1";
     }
     
     if (self.dorisUI.playerLayer != nil) {
-        [MUXSDKStats monitorAVPlayerLayer:self.dorisUI.playerLayer withPlayerName:@"dicePlayer" playerData:_playerData videoData:_videoData];
+        [MUXSDKStats monitorAVPlayerLayer:self.dorisUI.playerLayer withPlayerName:_playerName playerData:_playerData videoData:_videoData];
     } else if (self.dorisUI.playerViewController != nil) {
-        [MUXSDKStats monitorAVPlayerViewController:self.dorisUI.playerViewController withPlayerName:@"dicePlayer" playerData:_playerData videoData:_videoData];
+        [MUXSDKStats monitorAVPlayerViewController:self.dorisUI.playerViewController withPlayerName:_playerName playerData:_playerData videoData:_videoData];
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.22.0",
+    "version": "5.22.1",
     "exoDorisVersion": "0.13.0",
     "exoPlayerVersion": "2.13.3",
     "description": "A <Video /> element for react-native",

--- a/types/mux.ts
+++ b/types/mux.ts
@@ -7,4 +7,5 @@ export interface IMuxData {
   videoIsLive: boolean;
   videoStreamType: string;
   videoTitle: string;
+  playerName: string;
 }


### PR DESCRIPTION
## Description
Univision have requested that the following player names be used on Mux:

- Android TV: Android TV App
- Fire TV: Fire TV App
- tvOS: Apple TV App

## To do
- [x] Use `playerName` property to set player name sent to Mux
- [x] Bump library version

## JIRA
[DEV-3567](https://dicetech.atlassian.net/browse/DEV-3567)