### PR TITLE
Fix/DORIS-860: Behind live window for DRM streams

### DIFF
--- a/Video.tsx
+++ b/Video.tsx
@@ -137,6 +137,10 @@ export default class Video extends React.PureComponent<IVideoPlayer, IState> {
     this.props.onReloadCurrentSource?.(event.nativeEvent);
   }
 
+  onBehindLiveWindowError = (event) => {
+    this.props.onBehindLiveVideoError?.(event.nativeEvent);
+  }
+
   /**
    * seekTo jumps to a certain position for vod and live content
    * time parameter can be the following:
@@ -199,6 +203,7 @@ export default class Video extends React.PureComponent<IVideoPlayer, IState> {
       onVideoAboutToEnd: this.onVideoAboutToEnd,
       onFavouriteButtonClick: this.onFavouriteButtonClick,
       onReloadCurrentSource: this.onReloadCurrentSource,
+      onBehindLiveWindowError: this.onBehindLiveWindowError,
     };
   };
 

--- a/Video.tsx
+++ b/Video.tsx
@@ -138,7 +138,7 @@ export default class Video extends React.PureComponent<IVideoPlayer, IState> {
   }
 
   onBehindLiveWindowError = (event) => {
-    this.props.onBehindLiveVideoError?.(event.nativeEvent);
+    this.props.onBehindLiveWindowError?.(event.nativeEvent);
   }
 
   /**

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -1128,12 +1128,16 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
     }
 
     @Override
-    public void onPlayerError(ExoPlaybackException e) {
+    public void onPlayerError(@NonNull ExoPlaybackException e) {
         String errorString = null;
         Exception ex = e;
         if (isBehindLiveWindow(e)) {
-            clearResumePosition();
-            initializePlayer(false);
+            if (actionToken != null) {
+                eventEmitter.behindLiveWindowError();
+            } else {
+                clearResumePosition();
+                initializePlayer(false);
+            }
         } else if (!hasReloadedCurrentSource && isUnauthorizedException(e)) {
             hasReloadedCurrentSource = true;
             eventEmitter.reloadCurrentSource(src.getId(), metadata.getType());

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
@@ -39,6 +39,7 @@ class VideoEventEmitter {
     private static final String EVENT_VIDEO_ABOUT_TO_END = "onVideoAboutToEnd";
     private static final String EVENT_REQUIRE_AD_PARAMETERS = "onRequireAdParameters";
     private static final String EVENT_RELOAD_CURRENT_SOURCE = "onReloadCurrentSource";
+    private static final String EVENT_BEHIND_LIVE_WINDOW_ERROR = "onBehindLiveWindowError";
 
     private static final String EVENT_STALLED = "onPlaybackStalled";
     private static final String EVENT_RESUME = "onPlaybackResume";
@@ -90,7 +91,8 @@ class VideoEventEmitter {
             EVENT_VIDEO_ABOUT_TO_END,
             EVENT_FAVOURITE_BUTTON_CLICK,
             EVENT_REQUIRE_AD_PARAMETERS,
-            EVENT_RELOAD_CURRENT_SOURCE
+            EVENT_RELOAD_CURRENT_SOURCE,
+            EVENT_BEHIND_LIVE_WINDOW_ERROR
     };
 
     @Retention(RetentionPolicy.SOURCE)
@@ -125,7 +127,8 @@ class VideoEventEmitter {
             EVENT_VIDEO_ABOUT_TO_END,
             EVENT_FAVOURITE_BUTTON_CLICK,
             EVENT_REQUIRE_AD_PARAMETERS,
-            EVENT_RELOAD_CURRENT_SOURCE
+            EVENT_RELOAD_CURRENT_SOURCE,
+            EVENT_BEHIND_LIVE_WINDOW_ERROR
     })
     @interface VideoEvents {
     }
@@ -376,5 +379,9 @@ class VideoEventEmitter {
         event.putString(EVENT_PROP_ID, id);
         event.putString(EVENT_PROP_TYPE, type);
         receiveEvent(EVENT_RELOAD_CURRENT_SOURCE, event);
+    }
+
+    void behindLiveWindowError() {
+        receiveEvent(EVENT_BEHIND_LIVE_WINDOW_ERROR, null);
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
     "version": "5.23.4",
-    "exoDorisVersion": "0.13.5-alpha01",
+    "exoDorisVersion": "0.13.5",
     "exoPlayerVersion": "2.13.3",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
-    "version": "5.23.3",
-    "exoDorisVersion": "0.13.1",
+    "version": "5.23.4",
+    "exoDorisVersion": "0.13.5-alpha01",
     "exoPlayerVersion": "2.13.3",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",

--- a/types/callbacks.ts
+++ b/types/callbacks.ts
@@ -21,4 +21,5 @@ export interface IVideoPlayerCallbacks {
   onTimedMetadata?: (e: any) => void;
   onVideoAboutToEnd?: (e: any) => void;
   onReloadCurrentSource?: (e: any) => void;
+  onBehindLiveVideoError?: (e: any) => void;
 }

--- a/types/callbacks.ts
+++ b/types/callbacks.ts
@@ -21,5 +21,5 @@ export interface IVideoPlayerCallbacks {
   onTimedMetadata?: (e: any) => void;
   onVideoAboutToEnd?: (e: any) => void;
   onReloadCurrentSource?: (e: any) => void;
-  onBehindLiveVideoError?: (e: any) => void;
+  onBehindLiveWindowError?: (e: any) => void;
 }


### PR DESCRIPTION
## Description
Display an error dialog when the player falls behind the live window while playing a DRM protected live stream.

## To do
- [x] Add onBehindLiveWindowError event to player
- [x] Bump library version

## Screenshot
![Screenshot_1624025806](https://user-images.githubusercontent.com/5672768/122581417-ef8db480-d04e-11eb-9cf8-ea97f18f296f.png)


## JIRA
[DORIS-860](https://dicetech.atlassian.net/browse/DORIS-860)