### PR TITLE
Fix: Reset source URL after an error

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -1133,6 +1133,7 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
         Exception ex = e;
         if (isBehindLiveWindow(e)) {
             if (actionToken != null) {
+                resetSourceUrl();
                 eventEmitter.behindLiveWindowError();
             } else {
                 clearResumePosition();
@@ -1141,6 +1142,7 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
         } else if (!hasReloadedCurrentSource && isUnauthorizedException(e)) {
             hasReloadedCurrentSource = true;
             eventEmitter.reloadCurrentSource(src.getId(), metadata.getType());
+            resetSourceUrl();
         } else if (e.type == ExoPlaybackException.TYPE_RENDERER) {
             Exception cause = e.getRendererException();
             if (cause instanceof MediaCodecRenderer.DecoderInitializationException) {
@@ -1164,11 +1166,18 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
             errorString = getResources().getString(R.string.unrecognized_media_format);
         }
         if (errorString != null) {
+            resetSourceUrl();
             eventEmitter.error(errorString, ex);
         }
         playerNeedsSource = true;
         if (!isBehindLiveWindow(e)) {
             updateResumePosition();
+        }
+    }
+
+    private void resetSourceUrl() {
+        if (src != null) {
+            src.setUrl("");
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.23.4",
+    "version": "5.23.5",
     "exoDorisVersion": "0.13.5",
     "exoPlayerVersion": "2.13.3",
     "description": "A <Video /> element for react-native",


### PR DESCRIPTION
* Reset the source URL after getting an error, so the player can reload the new source provided by the JS layer.
* Bump library version