### PR TITLE
fix: adjust android exoplayer gradle dependency

### DIFF
--- a/android-exoplayer/build.gradle
+++ b/android-exoplayer/build.gradle
@@ -26,7 +26,7 @@ android {
 }
 
 dependencies {
-    implementation project(':ReactAndroid')
+    implementation 'com.facebook.react:react-native:+'
 
     // Amazon Publishing Services
     implementation project(":AmazonFireTVAdsSDK-release")

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
-    "version": "5.25.2",
-    "exoDorisVersion": "0.15.6",
+    "version": "5.25.3",
+    "exoDorisVersion": "0.15.7",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",


### PR DESCRIPTION
## Description
Adjust Android ExoPlayer `build.gradle` dependency to prevent TV builds from failing