### PR TITLE
chore: roll back exodoris version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
-    "version": "5.25.3",
-    "exoDorisVersion": "0.15.7",
+    "version": "5.25.4",
+    "exoDorisVersion": "0.15.6",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",


### PR DESCRIPTION
Chore: roll back `exoDorisVersion` (bumped version does not exist)