### PR TITLE
Fix: watermark props on android tv

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -1293,7 +1293,8 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
             int duration,
             String channelName,
             boolean apsTestFlag,
-            @Nullable String adTagUrl) {
+            @Nullable String adTagUrl,
+            Watermark watermark) {
         if (url != null) {
             String srcUrl = src != null ? src.getUrl() : null;
             boolean isOriginalSourceNull = srcUrl == null;
@@ -1329,21 +1330,20 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
                     apsTestFlag,
                     adTagUrl);
             this.actionToken = actionToken;
-
+            if (watermarkWidget != null) {
+                watermarkWidget.setWatermark(watermark);
+            }
             initializePlayer(!isOriginalSourceNull && !isSourceEqual);
         }
     }
 
-    public void setMetadata(RNMetadata metadata, Watermark watermark) {
+    public void setMetadata(RNMetadata metadata) {
         this.metadata = metadata;
 
         if (exoDorisPlayerView != null) {
             exoDorisPlayerView.setTitle(metadata.getTitle());
             exoDorisPlayerView.setDescription(metadata.getDescription());
             exoDorisPlayerView.setChannelLogo(metadata.getChannelLogoUrl());
-        }
-        if (watermarkWidget != null) {
-            watermarkWidget.setWatermark(watermark);
         }
     }
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
@@ -295,7 +295,7 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
                     description,
                     thumbnailUrl,
                     title,
-                    type);
+                    type));
         }
     }
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
@@ -59,6 +59,7 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
     private static final String PROP_SRC_HEADERS = "requestHeaders";
     private static final String PROP_SRC_APS = "aps";
     private static final String PROP_SRC_APS_TEST_MODE = "testMode";
+    private static final String PROP_SRC_METADATA = "metadata";
 
     // Metadata properties
     private static final String PROP_METADATA = "metadata";
@@ -213,6 +214,7 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
 
         ReadableMap config = src.hasKey(PROP_SRC_CONFIG) ? src.getMap(PROP_SRC_CONFIG) : null;
         ReadableMap muxData = (config != null && config.hasKey(PROP_SRC_MUX_DATA)) ? config.getMap(PROP_SRC_MUX_DATA) : null;
+        ReadableMap metadata = src.hasKey(PROP_SRC_METADATA) ? src.getMap(PROP_SRC_METADATA) : null;
 
         Map<String, String> headers = src.hasKey(PROP_SRC_HEADERS) ? toStringMap(src.getMap(PROP_SRC_HEADERS)) : null;
 
@@ -256,7 +258,8 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
                     duration != null ? Integer.parseInt(duration) : 0,
                     channelName,
                     apsTestMode,
-                    adTagUrl);
+                    adTagUrl,
+                    Watermark.fromMap(metadata));
         } else {
             int identifier = context.getResources().getIdentifier(
                     uriString,
@@ -292,8 +295,7 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
                     description,
                     thumbnailUrl,
                     title,
-                    type),
-                    Watermark.fromMap(metadata));
+                    type);
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.27.0",
+    "version": "5.27.1",
     "exoDorisVersion": "1.2.1",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",

--- a/types/metadata.ts
+++ b/types/metadata.ts
@@ -4,8 +4,4 @@ export interface IVideoPlayerMetadata {
   thumbnailUrl: string;
   title: string;
   type: string;
-  logoUrl?: string;
-  logoPosition?: string;
-  logoStaticDimension?: string;
-  logoPlayerSizeRatio?: number;
 }

--- a/types/source.ts
+++ b/types/source.ts
@@ -6,6 +6,13 @@ import { IVideoPlayerAPS } from './aps';
 
 type SourceType = 'mpd' | 'm3u8';
 
+export interface IVideoPlayerSourceMetadata {
+  logoUrl?: string;
+  logoPosition?: string;
+  logoStaticDimension?: string;
+  logoPlayerSizeRatio?: number;
+}
+
 export interface IVideoPlayerSource {
   uri: string;
   id?: string;
@@ -27,4 +34,5 @@ export interface IVideoPlayerSource {
   playlistId?: string;
   channelName?: string;
   adTagUrl?: string;
+  metadata?: IVideoPlayerSourceMetadata;
 }


### PR DESCRIPTION
Take watermark data from source.metadata instead of metadata prop, also revert ts changes.