### PR TITLE
Persist closed captions settings in local storage

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
@@ -64,6 +64,7 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
     private static final String PROP_SRC_APS_TEST_MODE = "testMode";
     private static final String PROP_SRC_METADATA = "metadata";
     private static final String PROP_SRC_LIMIT_RANGE = "limitedSeekableRange";
+    private static final String PROP_SRC_SAVE_SUBTITLE_SELECTION = "shouldSaveSubtitleSelection";
 
     // Metadata properties
     private static final String PROP_METADATA = "metadata";
@@ -231,6 +232,7 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
         boolean apsTestMode = (aps != null && aps.hasKey(PROP_SRC_APS_TEST_MODE)) && aps.getBoolean(PROP_SRC_APS_TEST_MODE);
 
         LimitedSeekRange limitedSeekRange = generateRange(src.hasKey(PROP_SRC_LIMIT_RANGE) ? src.getMap(PROP_SRC_LIMIT_RANGE) : null);
+        boolean shouldSaveSubtitleSelection = src.hasKey(PROP_SRC_SAVE_SUBTITLE_SELECTION) && src.getBoolean(PROP_SRC_SAVE_SUBTITLE_SELECTION);
 
         if (TextUtils.isEmpty(uriString)) {
             return;
@@ -283,7 +285,8 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
                     apsTestMode,
                     adTagUrl,
                     Watermark.fromMap(metadata),
-                    limitedSeekRange);
+                    limitedSeekRange,
+                    shouldSaveSubtitleSelection);
         } else {
             int identifier = context.getResources().getIdentifier(
                     uriString,

--- a/android-exoplayer/src/main/java/com/imggaming/tracks/TrackPreferenceStorage.java
+++ b/android-exoplayer/src/main/java/com/imggaming/tracks/TrackPreferenceStorage.java
@@ -1,0 +1,97 @@
+package com.imggaming.tracks;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import androidx.annotation.Nullable;
+
+/**
+ * A singleton storage that can be used to persist the preferred subtitle/audio track selections.
+ */
+public class TrackPreferenceStorage {
+
+    public static final String NONE = "none";
+
+    private static TrackPreferenceStorage INSTANCE;
+    private final SharedPreferences sharedPreferences;
+    private boolean enabled;
+
+    private TrackPreferenceStorage(Context context) {
+        sharedPreferences = context.getSharedPreferences("trackPreferenceStorage", Context.MODE_PRIVATE);
+    }
+
+    public static TrackPreferenceStorage getInstance(Context context) {
+        if (INSTANCE == null) {
+            INSTANCE = new TrackPreferenceStorage(context.getApplicationContext());
+        }
+        return INSTANCE;
+    }
+
+    /**
+     * Turn on/off the track preference storage. If this has been set to disabled, then the storage
+     * won't save any preferences and {@code getPreferredSubtitleLanguage}/{@code getPreferredAudioLanguage}
+     * will return null.
+     *
+     * @param enabled Whether to enable the track preference storage.
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+     * @return Return whether the track preference storage is turned on.
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Stores the preferred subtitle language.
+     *
+     * @param lang The language code of the subtitle.
+     */
+    public void storePreferredSubtitleLanguage(String lang) {
+        if (!enabled) return;
+        SharedPreferences.Editor editor = sharedPreferences.edit();
+        editor.putString("preferredSubtitleLanguage", lang);
+        editor.apply();
+    }
+
+    /**
+     * @return Returns the preferred subtitle language, or null if there is none.
+     */
+    @Nullable
+    public String getPreferredSubtitleLanguage() {
+        if (!enabled) return null;
+        return sharedPreferences.getString("preferredSubtitleLanguage", null);
+    }
+
+    /**
+     * @return Returns whether no subtitle is preferred.
+     */
+    public boolean isNoSubtitlePreferred() {
+        if (!enabled) return false;
+        return NONE.equals(getPreferredSubtitleLanguage());
+    }
+
+    /**
+     * Stores the preferred audio language.
+     *
+     * @param lang The language code of the audio.
+     */
+    public void storePreferredAudioLanguage(String lang) {
+        if (!enabled) return;
+        SharedPreferences.Editor editor = sharedPreferences.edit();
+        editor.putString("preferredAudioLanguage", lang);
+        editor.apply();
+    }
+
+    /**
+     * @return Returns the preferred audio language, or null if there is none.
+     */
+    @Nullable
+    public String getPreferredAudioLanguage() {
+        if (!enabled) return null;
+        return sharedPreferences.getString("preferredAudioLanguage", null);
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.29.1",
+    "version": "5.29.2",
     "exoDorisVersion": "2.0.3",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
     "version": "5.29.1",
-    "exoDorisVersion": "1.3.0",
+    "exoDorisVersion": "2.0.3",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",

--- a/types/source.ts
+++ b/types/source.ts
@@ -42,4 +42,5 @@ export interface IVideoPlayerSource {
   channelName?: string;
   adTagUrl?: string;
   metadata?: IVideoPlayerSourceMetadata;
+  shouldSaveSubtitleSelection?: boolean;
 }


### PR DESCRIPTION
Ticket: https://dicetech.atlassian.net/browse/DORIS-1528

Persist closed captions settings in local storage when the user select a subtitle track and preselect this subtitle track for subsequent videos. This feature is enabled only if the `shouldSaveSubtitleSelection` JS prop is `true` (this is realm setting and will be enabled for only WNBA for now).