### PR TITLE
Impr/doris 1436 migrate exo 2.18.1

### DIFF
--- a/android-exoplayer/build.gradle
+++ b/android-exoplayer/build.gradle
@@ -36,21 +36,15 @@ dependencies {
     implementation project(":AmazonFireTVAdsSDK-release")
 
     // ExoDoris
-    implementation("com.github.DiceTechnology.doris-android:doris:$exoDorisVersion") {
-        exclude group: "com.github.DiceTechnology", module: "dice-shield-android"
+    api ("com.github.DiceTechnology.doris-android:doris-ui:$exoDorisVersion"){
+        exclude group: 'com.github.DiceTechnology', module: 'dice-shield-android'
     }
-    implementation("com.github.DiceTechnology.doris-android:doris-ui:$exoDorisVersion") {
-        exclude group: "com.github.DiceTechnology", module: "dice-shield-android"
+    api ("com.github.DiceTechnology.doris-android:doris-custom-ui:$exoDorisVersion"){
+        exclude group: 'com.github.DiceTechnology', module: 'dice-shield-android'
     }
-    implementation("com.github.DiceTechnology.doris-android:extension-audio-only:$exoDorisVersion") {
-        exclude group: "com.github.DiceTechnology", module: "dice-shield-android"
-    }
-    implementation("com.github.DiceTechnology.doris-android:extension-ima-dai:$exoDorisVersion") {
-        exclude group: "com.github.DiceTechnology", module: "dice-shield-android"
-    }
-    implementation("com.github.DiceTechnology.doris-android:extension-ima-csai:$exoDorisVersion") {
-        exclude group: "com.github.DiceTechnology", module: "dice-shield-android"
-    }
+
+    // Stetho
+    api 'com.facebook.stetho:stetho-okhttp3:1.6.0'
 
     // Google Guava
     implementation "com.google.guava:guava:30.1-android"

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoDorisFactory.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoDorisFactory.java
@@ -14,7 +14,7 @@ import com.diceplatform.doris.entity.DorisAdEvent.AdType;
 import com.diceplatform.doris.ext.imacsai.ExoDorisImaCsaiBuilder;
 import com.diceplatform.doris.ext.imadai.ExoDorisImaDaiBuilder;
 import com.diceplatform.doris.plugin.Plugin;
-import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
+import com.google.android.exoplayer2.trackselection.DefaultTrackSelector.Parameters;
 import com.google.android.exoplayer2.ui.AdViewProvider;
 
 import java.util.List;
@@ -27,7 +27,7 @@ public final class ReactTVExoDorisFactory {
             int loadBufferMs,
             long forwardIncrementMs,
             long rewindIncrementMs,
-            @Nullable DefaultTrackSelector.Parameters.Builder parametersBuilder,
+            @Nullable Parameters.Builder parametersBuilder,
             @Nullable AdViewProvider adViewProvider) {
         return createPlayer(
                 context,
@@ -53,7 +53,7 @@ public final class ReactTVExoDorisFactory {
             long rewindIncrementMs,
             @Nullable List<Plugin> plugins,
             @Nullable SurfaceView surfaceView,
-            @Nullable DefaultTrackSelector.Parameters.Builder parametersBuilder,
+            @Nullable Parameters.Builder parametersBuilder,
             @Nullable AdViewProvider adViewProvider) {
         final ExoDorisBuilder builder;
         if (adType == AdType.IMA_DAI) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoDorisFactory.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoDorisFactory.java
@@ -27,7 +27,7 @@ public final class ReactTVExoDorisFactory {
             int loadBufferMs,
             long forwardIncrementMs,
             long rewindIncrementMs,
-            @Nullable DefaultTrackSelector.ParametersBuilder parametersBuilder,
+            @Nullable DefaultTrackSelector.Parameters.Builder parametersBuilder,
             @Nullable AdViewProvider adViewProvider) {
         return createPlayer(
                 context,
@@ -53,7 +53,7 @@ public final class ReactTVExoDorisFactory {
             long rewindIncrementMs,
             @Nullable List<Plugin> plugins,
             @Nullable SurfaceView surfaceView,
-            @Nullable DefaultTrackSelector.ParametersBuilder parametersBuilder,
+            @Nullable DefaultTrackSelector.Parameters.Builder parametersBuilder,
             @Nullable AdViewProvider adViewProvider) {
         final ExoDorisBuilder builder;
         if (adType == AdType.IMA_DAI) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -92,6 +92,7 @@ import com.google.android.exoplayer2.metadata.Metadata;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.text.CueGroup;
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
+import com.google.android.exoplayer2.trackselection.DefaultTrackSelector.Parameters;
 import com.google.android.exoplayer2.trackselection.MappingTrackSelector;
 import com.google.android.exoplayer2.trackselection.TrackSelectionOverride;
 import com.google.android.exoplayer2.util.Log;
@@ -492,8 +493,8 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
         }
         if (player == null) {
             AdType adType = (isImaDaiStream ? AdType.IMA_DAI : (isImaCsaiStream ? AdType.IMA_CSAI : null));
-            DefaultTrackSelector.Parameters.Builder parametersBuilder =
-                    new DefaultTrackSelector.Parameters.Builder(getContext())
+            Parameters.Builder parametersBuilder =
+                    new Parameters.Builder(getContext())
                     .setMaxVideoSize(viewWidth, viewHeight);
             player = exoDorisFactory.createPlayer(
                     getContext(),
@@ -1409,7 +1410,7 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
             type = "default";
         }
 
-        DefaultTrackSelector.Parameters disableParameters = trackSelector.getParameters()
+        Parameters disableParameters = trackSelector.getParameters()
                 .buildUpon()
                 .setRendererDisabled(rendererIndex, true)
                 .build();
@@ -1455,7 +1456,7 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
             return;
         }
 
-        DefaultTrackSelector.Parameters selectionParameters = trackSelector.getParameters()
+        Parameters selectionParameters = trackSelector.getParameters()
                 .buildUpon()
                 .setRendererDisabled(rendererIndex, false)
                 .setOverrideForType(new TrackSelectionOverride(groups.get(trackIndex), 0))
@@ -2000,6 +2001,14 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
     @Override
     public void onStatsButtonClicked() {
         eventEmitter.statsIconClick();
+    }
+
+    @Override
+    public void onSubtitleSelected(String language) {
+    }
+
+    @Override
+    public void onAudioSelected(String language) {
     }
 
     public void replaceAdTagParameters(Map<String, Object> replaceAdTagParametersMap) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -80,6 +80,7 @@ import com.google.android.exoplayer2.PlaybackException;
 import com.google.android.exoplayer2.PlaybackParameters;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.Timeline;
+import com.google.android.exoplayer2.Tracks;
 import com.google.android.exoplayer2.analytics.AnalyticsListener;
 import com.google.android.exoplayer2.audio.AudioAttributes;
 import com.google.android.exoplayer2.drm.DrmSession;
@@ -89,10 +90,10 @@ import com.google.android.exoplayer2.mediacodec.MediaCodecRenderer;
 import com.google.android.exoplayer2.mediacodec.MediaCodecUtil;
 import com.google.android.exoplayer2.metadata.Metadata;
 import com.google.android.exoplayer2.source.TrackGroupArray;
-import com.google.android.exoplayer2.text.Cue;
+import com.google.android.exoplayer2.text.CueGroup;
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
 import com.google.android.exoplayer2.trackselection.MappingTrackSelector;
-import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
+import com.google.android.exoplayer2.trackselection.TrackSelectionOverride;
 import com.google.android.exoplayer2.util.Log;
 import com.google.android.exoplayer2.util.Util;
 import com.google.gson.Gson;
@@ -491,8 +492,8 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
         }
         if (player == null) {
             AdType adType = (isImaDaiStream ? AdType.IMA_DAI : (isImaCsaiStream ? AdType.IMA_CSAI : null));
-            DefaultTrackSelector.ParametersBuilder parametersBuilder =
-                    new DefaultTrackSelector.ParametersBuilder(getContext())
+            DefaultTrackSelector.Parameters.Builder parametersBuilder =
+                    new DefaultTrackSelector.Parameters.Builder(getContext())
                     .setMaxVideoSize(viewWidth, viewHeight);
             player = exoDorisFactory.createPlayer(
                     getContext(),
@@ -508,7 +509,7 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
 
             AudioAttributes audioAttributes = new AudioAttributes.Builder()
                     .setUsage(C.USAGE_MEDIA)
-                    .setContentType(C.CONTENT_TYPE_MOVIE)
+                    .setContentType(C.AUDIO_CONTENT_TYPE_MOVIE)
                     .build();
 
             exoPlayer.setAudioAttributes(audioAttributes, false);
@@ -1140,7 +1141,7 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
     }
 
     @Override
-    public void onCues(List<Cue> cues) {
+    public void onCues(@NonNull CueGroup cueGroup) {
     }
 
     @Override
@@ -1187,7 +1188,7 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
     }
 
     @Override
-    public void onTracksChanged(TrackGroupArray trackGroups, TrackSelectionArray trackSelections) {
+    public void onTracksChanged(@NonNull Tracks tracksInfo) {
         // Do Nothing.
     }
 
@@ -1457,8 +1458,7 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
         DefaultTrackSelector.Parameters selectionParameters = trackSelector.getParameters()
                 .buildUpon()
                 .setRendererDisabled(rendererIndex, false)
-                .setSelectionOverride(rendererIndex, groups,
-                        new DefaultTrackSelector.SelectionOverride(trackIndex, 0))
+                .setOverrideForType(new TrackSelectionOverride(groups.get(trackIndex), 0))
                 .build();
         trackSelector.setParameters(selectionParameters);
     }

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
@@ -22,7 +22,6 @@ import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.DefaultLoadControl;
-import com.google.android.exoplayer2.endeavor.DebugUtil;
 import com.google.android.exoplayer2.endeavor.ExoConfig;
 import com.google.android.exoplayer2.endeavor.LimitedSeekRange;
 import com.google.android.exoplayer2.endeavor.WebUtil;
@@ -132,8 +131,6 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
     private static final int COMMAND_REPLACE_AD_TAG_PARAMETERS = 4;
     private static final int COMMAND_LIMIT_SEEKABLE_RANGE = 5;
 
-    private static final boolean IS_DEBUG = false;
-
     private final ReactApplicationContext reactApplicationContext;
     private LruCache<Integer, String> currentSrcUrls;
 
@@ -147,20 +144,13 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
     }
 
     private void setPlayerConfig() {
-        if (IS_DEBUG) {
-            DebugUtil.debug_drm = true;
-            DebugUtil.debug_media = true;
-            DebugUtil.debug_manifest = true;
-            // Change the ip and port to your file upload server.
-            DebugUtil.upload_server = "http://172.16.2.142:4660/file/manifest/";
-        }
         ExoConfig.getInstance().setHttpTimeoutMs(6000);
         ExoConfig.getInstance().setObtainKeyIdsFromManifest(true);
 
-        Log.d(WebUtil.DEBUG, String.format("config player - httpTimeoutMs %d, keyIdsMode %s, debug %b",
+        Log.i(WebUtil.DEBUG, String.format("config player - httpTimeoutMs %d, keyIdsMode %s, debug %b",
                 ExoConfig.getInstance().getHttpTimeoutMs(),
                 ExoConfig.getInstance().isObtainKeyIdsFromManifest() ? "manifest" : "stream",
-                IS_DEBUG));
+                BuildConfig.DEBUG));
     }
 
     @Override

--- a/android-exoplayer/src/main/java/com/imggaming/tracks/DcePlayerModel.java
+++ b/android-exoplayer/src/main/java/com/imggaming/tracks/DcePlayerModel.java
@@ -8,14 +8,13 @@ import com.brentvatne.react.R;
 import com.google.android.exoplayer2.C;
 import com.google.android.exoplayer2.ExoPlayer;
 import com.google.android.exoplayer2.Format;
+import com.google.android.exoplayer2.Tracks;
 import com.google.android.exoplayer2.source.TrackGroup;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
-import com.google.android.exoplayer2.trackselection.DefaultTrackSelector.ParametersBuilder;
-import com.google.android.exoplayer2.trackselection.DefaultTrackSelector.SelectionOverride;
 import com.google.android.exoplayer2.trackselection.MappingTrackSelector;
-import com.google.android.exoplayer2.trackselection.TrackSelection;
-import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
+import com.google.android.exoplayer2.trackselection.TrackSelectionOverride;
+import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -166,43 +165,23 @@ public class DcePlayerModel {
 
             final MappingTrackSelector.MappedTrackInfo mappedTrackInfo = trackSelector.getCurrentMappedTrackInfo();
             if (mappedTrackInfo != null) {
-                final TrackGroupArray tracks = mappedTrackInfo.getTrackGroups(index);
-
-                TrackSelectionArray selections = player.getCurrentTrackSelections();
-
-                TrackSelection selected = null;
-
-                for (int i = 0; i < selections.length; i++) {
-                    if (player.getRendererType(i) == trackType && selections.get(i) != null) {
-
-                        selected = selections.get(i);
+                Tracks tracks = player.getCurrentTracks();
+                for (int i = 0; i < tracks.getGroups().size(); i++) {
+                    Tracks.Group groupInfo = tracks.getGroups().get(i);
+                    if (groupInfo.getType() != trackType) {
+                        continue;
                     }
-                }
-
-                final List<TrackGroup> filtered = new ArrayList<>();
-                final List<Integer> indexes = new ArrayList<>();
-
-                for (int i = 0; i < tracks.length; i++) {
-                    TrackGroup group = tracks.get(i);
-                    if (!filtered.contains(group) && !TextUtils.isEmpty(getLabel(group))) {
-                        filtered.add(group);
-                        indexes.add(i);
-                    }
-                }
-
-                //Log.e(DcePlayerModel.class.getName(), "filtered = " + filtered.size() + " indexes = " + indexes);
-
-                for (int i = 0; i < filtered.size(); i++) {
-                    TrackGroup group = filtered.get(i);
-
-                    boolean isSelected = selected != null && tracks.indexOf(selected.getTrackGroup()) == indexes.get(i);
-
+                    TrackGroup group = groupInfo.getMediaTrackGroup();
                     String languageLabel = getLabel(group);
+                    if (TextUtils.isEmpty(languageLabel)) {
+                        continue;
+                    }
+                    boolean isSelected = groupInfo.isSelected();
 
                     Log.d(DcePlayerModel.class.getName(), " group =  " + languageLabel + " selected = " + isSelected);
 
                     if(!addedLanguages.contains(languageLabel)){
-                        ret.add(new DceTrack(languageLabel, indexes.get(i), isSelected));
+                        ret.add(new DceTrack(languageLabel, i, isSelected));
                         addedLanguages.add(languageLabel);
                     }
                 }
@@ -231,11 +210,9 @@ public class DcePlayerModel {
         final int index = findTrackTypeAvailable(trackType);
 
         if (index >= 0) {
-            ParametersBuilder parametersBuilder = trackSelector.buildUponParameters();
+            DefaultTrackSelector.Parameters.Builder parametersBuilder = trackSelector.buildUponParameters();
 
-            final TrackGroupArray groups = trackSelector.getCurrentMappedTrackInfo().getTrackGroups(index);
-
-            ArrayList<Integer> trackIndexes = new ArrayList<>();
+            ImmutableList<Tracks.Group> groups = player.getCurrentTracks().getGroups();
 
             int selected = -1;
 
@@ -247,9 +224,9 @@ public class DcePlayerModel {
             }
 
             if (selected >= 0) {
-                parametersBuilder.setSelectionOverride(index, groups, new SelectionOverride(selected, 0));
+                parametersBuilder.setOverrideForType(new TrackSelectionOverride(groups.get(selected).getMediaTrackGroup(), 0));
             } else {
-                parametersBuilder.clearSelectionOverrides(index);
+                parametersBuilder.clearOverridesOfType(trackType);
             }
 
             if (trackType == C.TRACK_TYPE_TEXT) { // enable/disable subtitles renderer

--- a/android-exoplayer/src/main/java/com/imggaming/tracks/DcePlayerModel.java
+++ b/android-exoplayer/src/main/java/com/imggaming/tracks/DcePlayerModel.java
@@ -12,6 +12,7 @@ import com.google.android.exoplayer2.Tracks;
 import com.google.android.exoplayer2.source.TrackGroup;
 import com.google.android.exoplayer2.source.TrackGroupArray;
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
+import com.google.android.exoplayer2.trackselection.DefaultTrackSelector.Parameters;
 import com.google.android.exoplayer2.trackselection.MappingTrackSelector;
 import com.google.android.exoplayer2.trackselection.TrackSelectionOverride;
 import com.google.common.collect.ImmutableList;
@@ -210,7 +211,7 @@ public class DcePlayerModel {
         final int index = findTrackTypeAvailable(trackType);
 
         if (index >= 0) {
-            DefaultTrackSelector.Parameters.Builder parametersBuilder = trackSelector.buildUponParameters();
+            Parameters.Builder parametersBuilder = trackSelector.buildUponParameters();
 
             ImmutableList<Tracks.Group> groups = player.getCurrentTracks().getGroups();
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
     "version": "5.29.1",
-    "exoDorisVersion": "1.3.0",
+    "exoDorisVersion": "77d09a01",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
     "version": "5.30.0",
-    "exoDorisVersion": "722c524b",
+    "exoDorisVersion": "4caee6c3",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
     "version": "5.30.0",
-    "exoDorisVersion": "4caee6c3",
+    "exoDorisVersion": "2.1.0",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
-    "version": "5.29.1",
-    "exoDorisVersion": "77d09a01",
+    "version": "5.30.0",
+    "exoDorisVersion": "87e5ccd8",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",


### PR DESCRIPTION
Currently we are waiting the release of ExoDoris 2.1.0 (included the exo 2.18.2 upgrade).
We should use ExoDoris 2.1.0 instead of the commit hash when ExoDoris 2.1.0 is released.

https://dicetech.atlassian.net/browse/DORIS-1436
https://dicetech.atlassian.net/browse/DORIS-1571

[DORIS-1436]: https://dicetech.atlassian.net/browse/DORIS-1436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DORIS-1571]: https://dicetech.atlassian.net/browse/DORIS-1571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ