### PR TITLE
Chore: bump doris-android to 2.2.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
-    "version": "5.30.2",
-    "exoDorisVersion": "2.2.8",
+    "version": "5.30.3",
+    "exoDorisVersion": "2.2.12",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",


### PR DESCRIPTION
Bump doris-android to fix the following build error: 
```
> Task :app:processAmazonDebugResources FAILED
Execution failed for task ':app:processAmazonDebugResources'.
> Android resource linking failed
  /Users/mb/.gradle/caches/transforms-3/5afff393714505c323ed437fbaf91885/transformed/res/values/values.xml:240:5-253:25: AAPT: error: resource attr/show_annotations_button (aka com.premierstreaming.app:attr/show_annotations_button) not found.
```

Change log (2.2.8 -> 2.2.12): https://github.com/DiceTechnology/doris-android/releases