### PR TITLE
fix: ClassCastException crash issue with emsg

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
@@ -323,30 +323,32 @@ class VideoEventEmitter {
     }
 
     void timedMetadata(Metadata metadata) {
-        WritableArray metadataArray = Arguments.createArray();
-
+        WritableArray metadataArray = null;
         for (int i = 0; i < metadata.length(); i++) {
+            Metadata.Entry entry = metadata.get(i);
+            if (!(entry instanceof Id3Frame)) {
+                continue;
+            }
 
-
-            Id3Frame frame = (Id3Frame) metadata.get(i);
-
+            if (metadataArray == null) {
+                metadataArray = Arguments.createArray();
+            }
             String value = "";
-
+            Id3Frame frame = (Id3Frame) entry;
             if (frame instanceof TextInformationFrame) {
                 TextInformationFrame txxxFrame = (TextInformationFrame) frame;
                 value = txxxFrame.value;
             }
-
             String identifier = frame.id;
-
             WritableMap map = Arguments.createMap();
             map.putString("identifier", identifier);
             map.putString("value", value);
-
             metadataArray.pushMap(map);
-
         }
 
+        if (metadataArray == null) {
+            return;
+        }
         WritableMap event = Arguments.createMap();
         event.putArray(EVENT_PROP_TIMED_METADATA, metadataArray);
         receiveEvent(EVENT_TIMED_METADATA, event);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "5.30.4",
+    "version": "5.30.5",
     "exoDorisVersion": "2.2.12",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",


### PR DESCRIPTION
https://dicetech.atlassian.net/browse/DORIS-1731

The app crashed when playing Setanta live stream which contain emsg metadata.
This PR fixed the ClassCastException issue when the metadata is emsg, not id3. 