### PR TITLE
Bump doris-android and dice-shield

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -16,7 +16,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.accessibility.CaptioningManager;
 import android.widget.FrameLayout;
-import android.widget.ImageView;
 
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
@@ -39,7 +38,6 @@ import com.brentvatne.receiver.AudioBecomingNoisyReceiver;
 import com.brentvatne.receiver.BecomingNoisyListener;
 import com.brentvatne.util.AdTagParametersHelper;
 import com.brentvatne.util.ImdbGenreMap;
-import com.bumptech.glide.Glide;
 import com.dice.shield.drm.entity.ActionToken;
 import com.diceplatform.doris.DorisPlayerOutput;
 import com.diceplatform.doris.ExoDoris;
@@ -1933,8 +1931,13 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
                     eventEmitter.playbackRateChange(1f);
                     break;
                 case PAUSED:
+                    eventEmitter.playbackRateChange(0f);
+                    break;
                 case ENDED:
                     eventEmitter.playbackRateChange(0f);
+                    if (exoDorisPlayerView != null) {
+                        exoDorisPlayerView.hideController();
+                    }
                     break;
             }
         }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
     "version": "6.0.0",
-    "exoDorisVersion": "2.5.0",
+    "exoDorisVersion": "2.5.1",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",
@@ -21,7 +21,7 @@
     },
     "dependencies": {
         "@dicetechnology/avdoris": "git+ssh://git@github.com/DiceTechnology/avdoris.git#semver:=1.11.0",
-        "@imggaming/dice-shield": "git+ssh://git@github.com:DiceTechnology/dice-shield.git#semver:=2.20.2",
+        "@imggaming/dice-shield": "git+ssh://git@github.com:DiceTechnology/dice-shield.git#semver:=2.20.8",
         "keymirror": "0.1.1",
         "prop-types": "^15.5.10"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "6.0.0",
+    "version": "6.0.1",
     "exoDorisVersion": "2.5.1",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",


### PR DESCRIPTION
* Bump `doris-android` to `2.5.1` to have the latest unified android tv adjustments [(UTV-447)](https://dicetech.atlassian.net/browse/UTV-447)
* Bump `dice-shield` to `2.20.8` to have the same version what is used in `doris-android 2.5.1`
* Hide controller when the stream ends, otherwise the info/language dialog could stay there forever