### PR TITLE
fix: change type of source for yospace ssai support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "6.3.1",
+    "version": "6.3.2",
     "dorisAndroidVersion": "3.4.0",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "6.3.2",
+    "version": "6.3.3",
     "dorisAndroidVersion": "3.4.9",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     },
     "dependencies": {
         "@dicetechnology/avdoris": "git+ssh://git@github.com/DiceTechnology/avdoris.git#semver:=1.12.7",
+        "@dicetechnology/dice-unity": "^2.26.3",
         "@imggaming/dice-shield": "git+ssh://git@github.com:DiceTechnology/dice-shield.git#semver:=2.23.0",
         "keymirror": "0.1.1",
         "prop-types": "^15.5.10"

--- a/types/source.ts
+++ b/types/source.ts
@@ -1,3 +1,5 @@
+import { IAdsConfiguration } from '@dicetechnology/dice-unity/lib/types/content'
+
 import { IVideoPlayerDRM } from './drm';
 import { IVideoPlayerIMA } from './ima';
 import { IMuxData } from './mux';
@@ -6,6 +8,11 @@ import { IVideoPlayerAPS } from './aps';
 import { INowPlaying } from "./nowPlaying";
 
 type SourceType = 'mpd' | 'm3u8';
+
+export enum ContentTypes {
+  HLS = 'application/x-mpegURL',
+  DASH = 'application/dash+xml',
+}
 
 export interface IVideoPlayerSourceMetadata {
   logoUrl?: string;
@@ -20,7 +27,13 @@ export interface IVideoPlayerSourceLimitedSeekableRange {
   seekToStart?: boolean;
 }
 
+export interface IAdsConfigurationExtended extends IAdsConfiguration {
+  provider?: string;
+}
+
 export interface IVideoPlayerSource {
+  ads?: IAdsConfigurationExtended;
+  contentType?: ContentTypes;
   uri: string;
   id?: string;
   subtitles?: IVideoPlayerSubtitles[];

--- a/types/source.ts
+++ b/types/source.ts
@@ -27,12 +27,8 @@ export interface IVideoPlayerSourceLimitedSeekableRange {
   seekToStart?: boolean;
 }
 
-export interface IAdsConfigurationExtended extends IAdsConfiguration {
-  provider?: string;
-}
-
 export interface IVideoPlayerSource {
-  ads?: IAdsConfigurationExtended;
+  ads?: IAdsConfiguration;
   contentType?: ContentTypes;
   uri: string;
   id?: string;


### PR DESCRIPTION
## Description
Change the type of source to add
- `ads` for adUnits v2
- `contentType`: content type for Android player

## Jira
[ADT-455](https://dicetech.atlassian.net/browse/ADT-455)

[ADT-455]: https://dicetech.atlassian.net/browse/ADT-455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ