### PR TITLE
[iOS/Android] Add Callback for Saving Subtitle Language

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/entity/RNSource.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/entity/RNSource.java
@@ -21,6 +21,7 @@ public class RNSource {
     private final Map<String, String> headers;
     private final Map<String, Object> muxData;
     private final String selectedAudioTrack;
+    private final String selectedSubtitleTrack;
     private final String locale;
     private final String channelId;
     private final String seriesId;
@@ -41,6 +42,7 @@ public class RNSource {
             @Nullable Map<String, String> headers,
             @Nullable Map<String, Object> muxData,
             @Nullable String selectedAudioTrack,
+            @Nullable String selectedSubtitleTrack,
             @Nullable String locale,
             @Nullable String channelId,
             @Nullable String seriesId,
@@ -59,6 +61,7 @@ public class RNSource {
         this.headers = headers;
         this.muxData = muxData;
         this.selectedAudioTrack = selectedAudioTrack;
+        this.selectedSubtitleTrack = selectedSubtitleTrack;
         this.locale = locale;
         this.channelId = channelId;
         this.seriesId = seriesId;
@@ -119,6 +122,11 @@ public class RNSource {
     @Nullable
     public String getSelectedAudioTrack() {
         return selectedAudioTrack;
+    }
+
+    @Nullable
+    public String getSelectedSubtitleTrack() {
+        return selectedSubtitleTrack;
     }
 
     @Nullable

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
@@ -70,6 +70,7 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
     private static final String PROP_SRC_SAVE_SUBTITLE_SELECTION = "shouldSaveSubtitleSelection";
     private static final String PROP_SRC_NOW_PLAYING = "nowPlaying";
     private static final String PROP_SRC_BIF_URL = "thumbnailsPreview";
+    private static final String PROP_SRC_SELECTED_SUBTITLE_TRACK = "selectedSubtitleTrack";
 
     // Metadata properties
     private static final String PROP_METADATA = "metadata";
@@ -244,6 +245,10 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
             videoView.setThumbnailsPreviewUrl(src.getString(PROP_SRC_BIF_URL));
         }
 
+        String selectedSubtitleTrack = src.hasKey(PROP_SRC_SELECTED_SUBTITLE_TRACK)
+                ? src.getString(PROP_SRC_SELECTED_SUBTITLE_TRACK)
+                : null;
+
         if (TextUtils.isEmpty(uriString)) {
             return;
         }
@@ -296,7 +301,8 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
                     adTagUrl,
                     Watermark.fromMap(metadata),
                     limitedSeekRange,
-                    shouldSaveSubtitleSelection);
+                    shouldSaveSubtitleSelection,
+                    selectedSubtitleTrack);
         } else {
             int identifier = context.getResources().getIdentifier(
                     uriString,
@@ -373,29 +379,13 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
     @ReactProp(name = PROP_SELECTED_AUDIO_TRACK)
     public void setSelectedAudioTrack(final ReactTVExoplayerView videoView,
                                       @Nullable ReadableMap selectedAudioTrack) {
-        String typeString = null;
-        Dynamic value = null;
-        if (selectedAudioTrack != null) {
-            typeString = selectedAudioTrack.hasKey(PROP_SELECTED_AUDIO_TRACK_TYPE)
-                    ? selectedAudioTrack.getString(PROP_SELECTED_AUDIO_TRACK_TYPE) : null;
-            value = selectedAudioTrack.hasKey(PROP_SELECTED_AUDIO_TRACK_VALUE)
-                    ? selectedAudioTrack.getDynamic(PROP_SELECTED_AUDIO_TRACK_VALUE) : null;
-        }
-        videoView.setSelectedAudioTrack(typeString, value);
+       // Deprecated, not used.
     }
 
     @ReactProp(name = PROP_SELECTED_TEXT_TRACK)
     public void setSelectedTextTrack(final ReactTVExoplayerView videoView,
                                      @Nullable ReadableMap selectedTextTrack) {
-        String typeString = null;
-        Dynamic value = null;
-        if (selectedTextTrack != null) {
-            typeString = selectedTextTrack.hasKey(PROP_SELECTED_TEXT_TRACK_TYPE)
-                    ? selectedTextTrack.getString(PROP_SELECTED_TEXT_TRACK_TYPE) : null;
-            value = selectedTextTrack.hasKey(PROP_SELECTED_TEXT_TRACK_VALUE)
-                    ? selectedTextTrack.getDynamic(PROP_SELECTED_TEXT_TRACK_VALUE) : null;
-        }
-        videoView.setSelectedTextTrack(typeString, value);
+        // Deprecated, not used.
     }
 
     @ReactProp(name = PROP_PAUSED, defaultBoolean = false)

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
@@ -60,6 +60,7 @@ class VideoEventEmitter {
     private static final String EVENT_RELATED_VIDEOS_ICON_CLICKED = "onRelatedVideosIconClicked";
     private static final String EVENT_FAVOURITE_BUTTON_CLICK = "onFavouriteButtonClick";
     private static final String EVENT_ANNOTATIONS_BUTTON_CLICK = "onAnnotationsButtonClick";
+    private static final String EVENT_SUBTITLE_TRACK_CHANGED = "onSubtitleTrackChanged";
 
     static final String[] Events = {
             EVENT_LOAD_START,
@@ -92,6 +93,7 @@ class VideoEventEmitter {
             EVENT_VIDEO_ABOUT_TO_END,
             EVENT_FAVOURITE_BUTTON_CLICK,
             EVENT_ANNOTATIONS_BUTTON_CLICK,
+            EVENT_SUBTITLE_TRACK_CHANGED,
             EVENT_REQUIRE_AD_PARAMETERS,
             EVENT_RELOAD_CURRENT_SOURCE,
             EVENT_BEHIND_LIVE_WINDOW_ERROR
@@ -129,6 +131,7 @@ class VideoEventEmitter {
             EVENT_VIDEO_ABOUT_TO_END,
             EVENT_FAVOURITE_BUTTON_CLICK,
             EVENT_ANNOTATIONS_BUTTON_CLICK,
+            EVENT_SUBTITLE_TRACK_CHANGED,
             EVENT_REQUIRE_AD_PARAMETERS,
             EVENT_RELOAD_CURRENT_SOURCE,
             EVENT_BEHIND_LIVE_WINDOW_ERROR
@@ -165,6 +168,7 @@ class VideoEventEmitter {
     private static final String EVENT_PROP_IS_ABOUT_TO_END = "isAboutToEnd";
     private static final String EVENT_PROP_DATE = "date";
     private static final String EVENT_PROP_IS_BLOCKING = "isBlocking";
+    private static final String EVENT_PROP_LANGUAGE = "language";
 
     private static final String EVENT_PROP_ERROR = "error";
     private static final String EVENT_PROP_ERROR_STRING = "errorString";
@@ -380,6 +384,12 @@ class VideoEventEmitter {
 
     void annotationsButtonClick() {
         receiveEvent(EVENT_ANNOTATIONS_BUTTON_CLICK, null);
+    }
+
+    void subtitleTrackChanged(String language) {
+        WritableMap map = Arguments.createMap();
+        map.putString(EVENT_PROP_LANGUAGE, language);
+        receiveEvent(EVENT_SUBTITLE_TRACK_CHANGED, map);
     }
 
     void requireAdParameters(double date, boolean isBlocking) {

--- a/ios/DorisTypesMappers/AVDorisSourceMapper.swift
+++ b/ios/DorisTypesMappers/AVDorisSourceMapper.swift
@@ -63,7 +63,7 @@ class AVDorisSourceMapper {
     
     private func sideloadedSubtitles(from source: Source) -> [DorisTextTrack] {
         var textTracks = [DorisTextTrack]()
-        if let subtitles = source.subtitles, source.live == false {
+        if let subtitles = source.subtitles, source.live != true {
             textTracks = subtitles
                 .compactMap{$0}
                 .filter{$0.isVtt}

--- a/ios/JSProps/Source.swift
+++ b/ios/JSProps/Source.swift
@@ -25,6 +25,7 @@ struct Source: SuperCodable {
     let thumbnailsPreview: URL?
     let limitedSeekableRange: LimitedSeekableRange?
     let nowPlaying: JSNowPlaying?
+    let selectedSubtitleTrack: String?
 }
 
 

--- a/ios/Video/JSInputProtocol.swift
+++ b/ios/Video/JSInputProtocol.swift
@@ -34,4 +34,5 @@ protocol JSInputProtocol: AnyObject {
     var onStatsIconClick: RCTBubblingEventBlock? { get }
     var onEpgIconClick: RCTBubblingEventBlock? { get }
     var onAnnotationsButtonClick: RCTBubblingEventBlock? { get }
+    var onSubtitleTrackChanged: RCTBubblingEventBlock? { get }
 }

--- a/ios/Video/PlayerView.swift
+++ b/ios/Video/PlayerView.swift
@@ -37,6 +37,7 @@ class PlayerView: UIView, JSInputProtocol {
     @objc var onStatsIconClick: RCTBubblingEventBlock?
     @objc var onEpgIconClick: RCTBubblingEventBlock?
     @objc var onAnnotationsButtonClick: RCTBubblingEventBlock?
+    @objc var onSubtitleTrackChanged: RCTBubblingEventBlock?    
     
     //Props
     //MARK: Differs (source)

--- a/ios/Video/RCTVideoManager.m
+++ b/ios/Video/RCTVideoManager.m
@@ -57,6 +57,7 @@ RCT_EXPORT_VIEW_PROPERTY(onRelatedVideosIconClicked, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onStatsIconClick, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onEpgIconClick, RCTBubblingEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onAnnotationsButtonClick, RCTBubblingEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onSubtitleTrackChanged, RCTBubblingEventBlock);
 
 RCT_EXTERN_METHOD(seekToNow:(nonnull NSNumber *)node)
 RCT_EXTERN_METHOD(seekToTimestamp:(nonnull NSNumber *)node isoDate:(NSString *)isoDate)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
     "version": "6.3.1",
-    "dorisAndroidVersion": "3.4.0",
+    "dorisAndroidVersion": "3.4.9",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "6.3.1",
+    "version": "6.3.2",
     "dorisAndroidVersion": "3.4.9",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",

--- a/types/callbacks.ts
+++ b/types/callbacks.ts
@@ -23,4 +23,5 @@ export interface IVideoPlayerCallbacks {
   onVideoAboutToEnd?: (e: any) => void;
   onReloadCurrentSource?: (e: any) => void;
   onBehindLiveWindowError?: (e: any) => void;
+  onSubtitleTrackChanged?: ({ language: string }) => void;
 }

--- a/types/source.ts
+++ b/types/source.ts
@@ -46,4 +46,5 @@ export interface IVideoPlayerSource {
   shouldSaveSubtitleSelection?: boolean;
   nowPlaying: INowPlaying;
   thumbnailsPreview?: string;
+  selectedSubtitleTrack?: string;
 }


### PR DESCRIPTION
Tickets:
* https://dicetech.atlassian.net/browse/UTV-984
* https://dicetech.atlassian.net/browse/UTV-1106

Whenever the user changes the subtitle we are exposing this event `onSubtitleTrackChanged` that contains the selected `language` as a param. 
To preselect a subtitle when starting a stream, the language code needs to be passed via the `src/selectedSubtitleTrack` prop.