### PR TITLE
chore: fix the onVideoAboutToEnd issue with post-roll ad

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
-    "version": "6.4.6",
-    "dorisAndroidVersion": "3.4.13",
+    "version": "6.4.7",
+    "dorisAndroidVersion": "3.5.1",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",


### PR DESCRIPTION
Ticket: https://dicetech.atlassian.net/browse/ADT-519

* Fix the onVideoAboutToEnd issue for the case timeline and seekbar duration are different.
* Bump the doris-android to latest 3.5.1.