### PR TITLE
chore: bump the doris-android to 3.5.10 to fix the dice cbcs stream n…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
-    "version": "6.5.4",
-    "dorisAndroidVersion": "3.5.8",
+    "version": "6.5.5",
+    "dorisAndroidVersion": "3.5.10",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",


### PR DESCRIPTION
Ticket https://dicetech.atlassian.net/browse/ADT-567

Bump the doris-android to 3.5.10, to fix the dice cbcs stream not playing on FireTV.