### PR TITLE
chore: bump avdoris 1.17.1

### DIFF
--- a/ios/JSProps/Metadata.swift
+++ b/ios/JSProps/Metadata.swift
@@ -41,11 +41,10 @@ extension Metadata {
             let logoPlayerSizeRatio = logoPlayerSizeRatio
         else { return nil }
         
-        var watermarkViewModel = WatermarkViewModel()
-        watermarkViewModel.watermarkURL = logoUrl
-        watermarkViewModel.watermarkPosition = AVDoris.WatermarkPosition(rawValue: logoPosition.rawValue) ?? .topRight
-        watermarkViewModel.watermarkStaticDimention = AVDoris.WatermarkStaticDimention(rawValue: logoStaticDimension.rawValue) ?? .height
-        watermarkViewModel.watermarkSuperviewRatio = logoPlayerSizeRatio
+        var watermarkViewModel = WatermarkViewModel(watermarkURL: logoUrl,
+                                                    watermarkPosition: AVDoris.WatermarkPosition(rawValue: logoPosition.rawValue) ?? .topRight,
+                                                    watermarkStaticDimention: AVDoris.WatermarkStaticDimention(rawValue: logoStaticDimension.rawValue) ?? .height,
+                                                    watermarkSuperviewRatio: logoPlayerSizeRatio)
         
         return watermarkViewModel
     }

--- a/ios/Video/JSDoris.swift
+++ b/ios/Video/JSDoris.swift
@@ -66,7 +66,7 @@ class JSDoris {
             self.doris?.viewModel.labels.metadata.description = metadata?.description
             self.doris?.viewModel.labels.metadata.episodeInfo = metadata?.episodeInfo
             self.doris?.viewModel.images.backgroundImageURL = metadata?.thumbnailUrl
-            self.doris?.viewModel.images.watermarkViewModel = metadata?.watermarkModel ?? WatermarkViewModel()
+            self.doris?.viewModel.images.watermarkViewModel = metadata?.watermarkModel
         }
         
         props.controls.bindAndFire { [weak self] isEnabled in

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "eslint-plugin-react": "3.16.1"
     },
     "dependencies": {
-        "@dicetechnology/avdoris": "git+ssh://git@github.com/DiceTechnology/avdoris.git#semver:=1.15.12",
+        "@dicetechnology/avdoris": "git+ssh://git@github.com/DiceTechnology/avdoris.git#semver:=1.17.1",
         "@dicetechnology/dice-unity": "^2.26.3",
         "@imggaming/dice-shield": "git+ssh://git@github.com:DiceTechnology/dice-shield.git#semver:=2.23.0",
         "keymirror": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "6.5.8",
+    "version": "6.5.9",
     "dorisAndroidVersion": "3.5.14",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",


### PR DESCRIPTION
- change ad markers color from white to yellow
- fix ad markers are shown under left side of seekbar progress on iOS but above on web/android
- fix ad markers are missing for csai live midrolls
- visible ad frame after fix restart
- move watermark inside video rect