### PR TITLE
doris-2094 content time

### DIFF
--- a/ios/Video/JSDoris.swift
+++ b/ios/Video/JSDoris.swift
@@ -241,8 +241,8 @@ extension JSDoris: DorisOutputProtocol {
                 let isAboutToEnd = contentPosition >= duration - 5
                 output?.onVideoAboutToEnd?(["isAboutToEnd": isAboutToEnd]);
             }
-        case .itemDurationChanged(duration: let duration):
-            currentPlayingItemDuration = duration
+        case .itemDurationChanged(let contentDuration, _):
+            currentPlayingItemDuration = contentDuration
         case .playerItemFailed:
             output?.onVideoError?(nil)
         default: break

--- a/ios/Video/JSDoris.swift
+++ b/ios/Video/JSDoris.swift
@@ -232,13 +232,13 @@ extension JSDoris: DorisOutputProtocol {
             }
         case .finishedPlaying(endTime: _):
             output?.onVideoEnd?(nil)
-        case .currentTimeChanged(let seconds, _):
-            if seconds > 0 {
-                output?.onVideoProgress?(["currentTime": seconds])
+        case .currentTimeChanged(let contentPosition, let streamPosition, _):
+            if streamPosition > 0 {
+                output?.onVideoProgress?(["currentTime": contentPosition])
             }
             
             if let duration = currentPlayingItemDuration {
-                let isAboutToEnd = seconds >= duration - 5
+                let isAboutToEnd = streamPosition >= duration - 5
                 output?.onVideoAboutToEnd?(["isAboutToEnd": isAboutToEnd]);
             }
         case .itemDurationChanged(duration: let duration):

--- a/ios/Video/JSDoris.swift
+++ b/ios/Video/JSDoris.swift
@@ -232,13 +232,13 @@ extension JSDoris: DorisOutputProtocol {
             }
         case .finishedPlaying(endTime: _):
             output?.onVideoEnd?(nil)
-        case .currentTimeChanged(let contentPosition, let streamPosition, _):
-            if streamPosition > 0 {
+        case .currentTimeChanged(let contentPosition, _, _):
+            if contentPosition > 0 {
                 output?.onVideoProgress?(["currentTime": contentPosition])
             }
             
             if let duration = currentPlayingItemDuration {
-                let isAboutToEnd = streamPosition >= duration - 5
+                let isAboutToEnd = contentPosition >= duration - 5
                 output?.onVideoAboutToEnd?(["isAboutToEnd": isAboutToEnd]);
             }
         case .itemDurationChanged(duration: let duration):

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "eslint-plugin-react": "3.16.1"
     },
     "dependencies": {
-        "@dicetechnology/avdoris": "git+ssh://git@github.com/DiceTechnology/avdoris.git#semver:=1.17.11",
+        "@dicetechnology/avdoris": "git+ssh://git@github.com/DiceTechnology/avdoris.git#semver:=1.17.12",
         "@dicetechnology/dice-unity": "^2.26.3",
         "@imggaming/dice-shield": "git+ssh://git@github.com:DiceTechnology/dice-shield.git#semver:=2.23.0",
         "keymirror": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "6.5.11",
+    "version": "6.5.12",
     "dorisAndroidVersion": "3.6.5",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
@@ -20,7 +20,7 @@
         "eslint-plugin-react": "3.16.1"
     },
     "dependencies": {
-        "@dicetechnology/avdoris": "git+ssh://git@github.com/DiceTechnology/avdoris.git#semver:=1.17.10",
+        "@dicetechnology/avdoris": "git+ssh://git@github.com/DiceTechnology/avdoris.git#semver:=1.17.11",
         "@dicetechnology/dice-unity": "^2.26.3",
         "@imggaming/dice-shield": "git+ssh://git@github.com:DiceTechnology/dice-shield.git#semver:=2.23.0",
         "keymirror": "0.1.1",


### PR DESCRIPTION
## Feat

- Expose a new contentTime prop to the JavaScript layer that excludes ad periods from the current (stream) time.
- contentTime exposed via the onProgress event, and contentDuration exposed via onDurationChanged event.

## Jira

[DORIS-2094](https://dicetech.atlassian.net/browse/DORIS-2094)
[UTV-1578](https://dicetech.atlassian.net/browse/UTV-1578)

[DORIS-2094]: https://dicetech.atlassian.net/browse/DORIS-2094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[UTV-1578]: https://dicetech.atlassian.net/browse/UTV-1578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ