### PR TITLE
DORIS-2095: Expose content time to JS without ad duration

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -227,9 +227,9 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
             if (msg.what == SHOW_JS_PROGRESS) {
                 ExoPlayer exoPlayer = (player == null ? null : player.getExoPlayer());
                 if (exoPlayer != null && exoPlayer.getPlaybackState() == Player.STATE_READY && exoPlayer.getPlayWhenReady()) {
-                    long position = player.getCurrentPosition();
-                    long bufferedDuration = player.getBufferedPosition();
-                    long duration = player.getDuration();
+                    long position = player.getContentPosition();
+                    long bufferedDuration = player.getContentBufferedPosition();
+                    long duration = player.getContentDuration();
 
                     if (!isLive) {
                         boolean isAboutToEnd = duration - position <= VIDEO_ABOUT_TO_END_TIME_MS;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
-    "version": "6.5.12",
-    "dorisAndroidVersion": "3.6.5",
+    "version": "6.5.13",
+    "dorisAndroidVersion": "3.6.6",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",


### PR DESCRIPTION
Ticket: https://dicetech.atlassian.net/browse/DORIS-2095