### PR TITLE
Fix/drm playback retry l3

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -1,7 +1,5 @@
 package com.brentvatne.exoplayer;
 
-import static com.diceplatform.doris.entity.DorisPlayerEvent.Event.TIMELINE_ADJUSTER_CHANGED;
-
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.media.AudioManager;
@@ -926,7 +924,8 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
 
     @Override
     public void onDrmSessionManagerError(EventTime eventTime, Exception e) {
-        handleDrmSessionManagerError(e);
+        // Not need redundant error handle, we use dorisListener to handle all ERROR events of internal doris player.
+        // handleDrmSessionManagerError(e);
     }
 
     @Override
@@ -1137,19 +1136,22 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
 
     @Override
     public void onPlayerError(@NonNull PlaybackException error) {
+        // Not need redundant error handle, we use dorisListener to handle all ERROR events of internal doris player.
+        playerNeedsSource = true;
+        if (!DorisExceptionUtil.isBehindLiveWindow(error)) {
+            updateResumePosition();
+        }
+    }
+
+    private void handlePlaybackError(PlaybackException error) {
         String errorString = null;
         Exception ex = error;
         @ExoPlaybackException.Type int errorType = DorisExceptionUtil.getErrorType(error);
         if (DorisExceptionUtil.isBehindLiveWindow(error)) {
-            ExoPlayer exoPlayer = (player == null ? null : player.getExoPlayer());
-            if (exoPlayer != null) {
-                clearResumePosition();
-                exoPlayer.seekToDefaultPosition();
-                exoPlayer.prepare();
-            }
+          // We handle behind-live-window error in internal doris player.
         } else if (!hasReloadedCurrentSource && DorisExceptionUtil.isUnauthorizedException(error)) {
             hasReloadedCurrentSource = true;
-            eventEmitter.reloadCurrentSource(src.getId(), metadata.getType());
+            reloadCurrentSource();
             resetSourceUrl();
         } else if (errorType == ExoPlaybackException.TYPE_RENDERER) {
             Exception cause = (Exception) error.getCause();
@@ -1181,10 +1183,15 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
             resetSourceUrl();
             eventEmitter.error("Playback exception: " + errorString, ex);
         }
-        playerNeedsSource = true;
-        if (!DorisExceptionUtil.isBehindLiveWindow(error)) {
-            updateResumePosition();
+    }
+
+    private void reloadCurrentSource() {
+        if (src != null && metadata != null) {
+            Log.i(TAG, "Reload current source, id " + src.getId() + ", type " + metadata.getType());
+            eventEmitter.reloadCurrentSource(src.getId(), metadata.getType());
+            return;
         }
+        Log.i(TAG, "Reload current source, ignored for src or metadata is null");
     }
 
     private void resetSourceUrl() {
@@ -1840,8 +1847,27 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
                     }
                     break;
             }
-            if (playerEvent.event == TIMELINE_ADJUSTER_CHANGED && exoDorisPlayerView != null) {
-                exoDorisPlayerView.setExtraTimelineAdjuster(playerEvent.details.timelineAdjuster);
+
+            switch (playerEvent.event) {
+                case TIMELINE_ADJUSTER_CHANGED:
+                    if (exoDorisPlayerView != null) {
+                        exoDorisPlayerView.setExtraTimelineAdjuster(playerEvent.details.timelineAdjuster);
+                    }
+                    break;
+                case RELOAD_WITH_DRM_L3:
+                    reloadCurrentSource();
+                    break;
+                case ERROR:
+                    Exception error = playerEvent.details.error;
+                    if (error instanceof PlaybackException) {
+                        handlePlaybackError((PlaybackException) error);
+                    } else if (error != null) {
+                        resetSourceUrl();
+                        eventEmitter.error("Player exception", error);
+                    }
+                    break;
+                default:
+                    break;
             }
         }
 
@@ -1903,7 +1929,7 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
                         if (!hasReloadedCurrentSource && isUnauthorizedAdError(error)) {
                             hasReloadedCurrentSource = true;
                             ignoreAdError = true;
-                            eventEmitter.reloadCurrentSource(src.getId(), metadata.getType());
+                            reloadCurrentSource();
                         }
                     }
                     if (!ignoreAdError) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
@@ -289,7 +289,8 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
             Pair<ImaCsaiProperties, YoSsaiProperties> adProperties = ReactTVPropsParser.parseAdUnitsV2(videoView.isLive(), src);
             TracksPolicy tracksPolicy = ReactTVPropsParser.parseTracksPolicy(ReadableMapUtils.getMap(src, "tracksPolicy"));
 
-            Log.i(WebUtil.DEBUG, String.format("setSrc - title %s, mimeType %s, isYoSsai %b, isImaDai %b, adTag %s, midRoll %s, license %s, url %s",
+            Log.i(WebUtil.DEBUG, String.format("setSrc - id %s, title %s, mimeType %s, isYoSsai %b, isImaDai %b, adTag %s, midRoll %s, license %s, url %s",
+                    id,
                     channelName == null && muxData != null && muxData.hasKey("videoTitle") ? muxData.getString("videoTitle") : channelName,
                     mimeType,
                     adProperties.second != null,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
-    "version": "7.3.1",
-    "dorisAndroidVersion": "0383f8ae",
+    "version": "7.3.2",
+    "dorisAndroidVersion": "3.7.2",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
     "version": "7.3.0",
-    "dorisAndroidVersion": "3.7.0",
+    "dorisAndroidVersion": "63cdc54d",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
     "version": "7.3.0",
-    "dorisAndroidVersion": "63cdc54d",
+    "dorisAndroidVersion": "ec690246",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",


### PR DESCRIPTION
Ticket: https://dicetech.atlassian.net/browse/DORIS-2178

Try to reload current source after downgrade to L3 security level.
Need to bump the doris-andriod version after the PR https://github.com/DiceTechnology/doris-android/pull/494 is merged.

Now we bump the doris-android version from 3.7.0 to 3.7.2, it included
- send selected audio language to mux
- support playback on mixed-ts-cmaf stream.
- reload current source after downgrade to L3 security level.
- bump yospace ad sdk to 3.6.7