### PR TITLE
fix：UTV-1889-[TVOS] | Player|Label for In Player Watchlist button dis…

### DIFF
--- a/ios/Video/PlayerViewProxy.swift
+++ b/ios/Video/PlayerViewProxy.swift
@@ -89,7 +89,7 @@ class PlayerViewProxy {
             dorisTranslationsViewModel.audioAndSubtitles = translationsValue.playerAudioAndSubtitlesButton
             dorisTranslationsViewModel.live = translationsValue.goLive
             dorisTranslationsViewModel.favourites = translationsValue.favourite
-            dorisTranslationsViewModel.addToWatchlist = translationsValue.watchlist
+            dorisTranslationsViewModel.addToWatchlist = translationsValue.addToWatchlist
             dorisTranslationsViewModel.moreVideos = translationsValue.moreVideos
             dorisTranslationsViewModel.rewind = translationsValue.rewind
             dorisTranslationsViewModel.fastForward = translationsValue.fastForward

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "7.3.3",
+    "version": "7.3.4",
     "dorisAndroidVersion": "3.7.2",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",


### PR DESCRIPTION
fix : [TVOS] | Player|Label for In Player Watchlist button displayed incorrectly '__#watchlist##__'
[UTV-1889](https://dicetech.atlassian.net/browse/UTV-1889)

[UTV-1889]: https://dicetech.atlassian.net/browse/UTV-1889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ