### PR TITLE
Fix/timeline show wrong ad position

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "7.4.17",
+    "version": "7.4.18",
     "dorisAndroidVersion": "3.9.20",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
     "version": "7.4.17",
-    "dorisAndroidVersion": "3.9.19",
+    "dorisAndroidVersion": "3.9.20",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",


### PR DESCRIPTION
bump doris-android to 3.9.20 to fix timeline wrong ad position in android tv.