### PR TITLE
chore: bump rnvd version to 6.63.2 for the skip marker RTL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "7.4.19",
+    "version": "7.4.20",
     "dorisAndroidVersion": "3.9.20",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
@@ -20,7 +20,7 @@
         "eslint-plugin-react": "3.16.1"
     },
     "dependencies": {
-        "@dicetechnology/react-native-dice-video": "git+ssh://git@github.com:DiceTechnology/react-native-dice-video.git#6.61.5",
+        "@dicetechnology/react-native-dice-video": "git+ssh://git@github.com:DiceTechnology/react-native-dice-video.git#6.63.2",
         "@dicetechnology/dice-unity": "^2.26.3",
         "keymirror": "0.1.1",
         "prop-types": "^15.5.10"


### PR DESCRIPTION

bump rnvd version to 6.63.2 for the skip marker RTL

[UTV-2348](https://dicetech.atlassian.net/browse/UTV-2348)

[UTV-2348]: https://dicetech.atlassian.net/browse/UTV-2348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ