### PR TITLE
UTV-2414: Fix the time unit of the currentDate progress

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
@@ -231,9 +231,7 @@ class VideoEventEmitter {
             double bufferedDuration,
             double seekableDuration) {
         WritableMap event = Arguments.createMap();
-        // We are using milliseconds instead of seconds here, due to iOS has used milliseconds.
-        //  we should keep consistent with iOS
-        event.putDouble(EVENT_PROP_CURRENT_DATE, currentDate);
+        event.putDouble(EVENT_PROP_CURRENT_DATE, currentDate / 1000D);
         event.putDouble(EVENT_PROP_CURRENT_TIME, currentPosition / 1000D);
         event.putDouble(EVENT_PROP_PLAYABLE_DURATION, bufferedDuration / 1000D);
         event.putDouble(EVENT_PROP_SEEKABLE_DURATION, seekableDuration / 1000D);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "7.5.2",
+    "version": "7.5.3",
     "dorisAndroidVersion": "3.9.24",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",


### PR DESCRIPTION
Change `currentDate` time unit from ms to seconds.

Ticket: https://dicetech.atlassian.net/browse/UTV-2414