### PR TITLE
Bump doris-android to 3.9.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
-    "version": "7.5.5",
-    "dorisAndroidVersion": "3.9.27",
+    "version": "7.5.6",
+    "dorisAndroidVersion": "3.9.28",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",


### PR DESCRIPTION
Ticket: https://dicetech.atlassian.net/browse/ADT-1144

Bump doris-android to 3.9.28, to fix the seek rewind near ads on yospace ad stream.