### PR TITLE
fix:ADT-1159, ADT-1160, ADT-1156

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "7.5.6",
+    "version": "7.5.7",
     "dorisAndroidVersion": "3.9.29",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
     "version": "7.5.6",
-    "dorisAndroidVersion": "3.9.28",
+    "dorisAndroidVersion": "3.9.29",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",
@@ -20,7 +20,7 @@
         "eslint-plugin-react": "3.16.1"
     },
     "dependencies": {
-        "@dicetechnology/react-native-dice-video": "git+ssh://git@github.com:DiceTechnology/react-native-dice-video.git#6.66.1",
+        "@dicetechnology/react-native-dice-video": "git+ssh://git@github.com:DiceTechnology/react-native-dice-video.git#6.67.3",
         "@dicetechnology/dice-unity": "^2.26.3",
         "keymirror": "0.1.1",
         "prop-types": "^15.5.10"


### PR DESCRIPTION
Fixed bugs:
- ADT-1159-[Android TV] - Unable to Skip Behind SCTE Start Using 30s Skip Option on Screen
- ADT-1160-[Fire TV] - Unable to Skip Behind SCTE Start Using 30s Skip Option on Screen
- ADT-1156-[tv OS] - Digital ads are not skipped for repeat viewings