### PR TITLE
chore: bump doris-android to 3.9.46

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
-    "version": "7.5.16",
-    "dorisAndroidVersion": "3.9.44",
+    "version": "7.5.17",
+    "dorisAndroidVersion": "3.9.45",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
     "version": "7.5.17",
-    "dorisAndroidVersion": "3.9.45",
+    "dorisAndroidVersion": "3.9.46",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
     "license": "MIT",


### PR DESCRIPTION
JIRA: [UTV-2606](https://dicetech.atlassian.net/browse/UTV-2606)

AndroidTV | Why this Ad side panel doesn't appear [**Fixed**]

upgrade doris-android to 3.9.46


[UTV-2606]: https://dicetech.atlassian.net/browse/UTV-2606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ