### PR TITLE
fix: sync translations to rndv

### DIFF
--- a/ios/Video/NewPlayerView.swift
+++ b/ios/Video/NewPlayerView.swift
@@ -64,7 +64,15 @@ class NewPlayerView: UIView, JSInputProtocol {
     @objc var partialVideoInformation: NSDictionary? {
         didSet { jsProps.partialVideoInformation.value = try? PartialVideoInformation(dict: partialVideoInformation) } }
     @objc var translations: NSDictionary? {
-        didSet { jsProps.translations.value = try? Translations(dict: translations) } }
+        didSet {
+            let translationsModel = try? Translations(dict: translations)
+            jsProps.translations.value = translationsModel
+            if let translationsModel, jsPlayerView?.dorisGlue != nil, translations != oldValue {
+                let dorisTranslations = PlayerViewProxy.convertRNVideoTranslationsToDorisTranslations(translations: translationsModel)
+                jsPlayerView?.dorisGlue?.doris?.viewModel.rendering.translationsViewModel = dorisTranslations
+            }
+        }
+    }
     @objc var buttons: NSDictionary? {
         didSet { jsProps.buttons.value = try? Buttons(dict: buttons) } }
     @objc var theme: NSDictionary? {

--- a/ios/Video/PlayerViewProxy.swift
+++ b/ios/Video/PlayerViewProxy.swift
@@ -81,36 +81,38 @@ class PlayerViewProxy {
     }
     
     private static func convertRNVideoTranslationsToRNDV(translations: Translations?) -> JSTranslations? {
-        var jsTranslations: JSTranslations?
-        if let translationsValue = translations {
-            var dorisTranslationsViewModel = DorisTranslationsViewModel()
-            dorisTranslationsViewModel.play = translationsValue.playerPlayButton
-            dorisTranslationsViewModel.pause = translationsValue.playerPauseButton
-            dorisTranslationsViewModel.stats = translationsValue.playerStatsButton
-            dorisTranslationsViewModel.audioAndSubtitles = translationsValue.playerAudioAndSubtitlesButton
-            dorisTranslationsViewModel.live = translationsValue.goLive
-            dorisTranslationsViewModel.favourites = translationsValue.favourite
-            dorisTranslationsViewModel.addToWatchlist = translationsValue.addToWatchlist
-            dorisTranslationsViewModel.moreVideos = translationsValue.moreVideos
-            dorisTranslationsViewModel.audio = translationsValue.audioTracks
-            dorisTranslationsViewModel.info = translationsValue.info
-            dorisTranslationsViewModel.adsCountdownAd = translationsValue.adsCountdownAd
-            dorisTranslationsViewModel.adsCountdownOf = translationsValue.adsCountdownOf
-            dorisTranslationsViewModel.annotations = translationsValue.annotations
-            dorisTranslationsViewModel.playingLive = translationsValue.playingLive
-            dorisTranslationsViewModel.nowPlaying = translationsValue.nowPlaying
-            dorisTranslationsViewModel.subtitles = translationsValue.captions
-            dorisTranslationsViewModel.skipIntro = translationsValue.skipIntro
-            dorisTranslationsViewModel.skipCredits = translationsValue.skipCredits
-            dorisTranslationsViewModel.rewind = translationsValue.rewind
-            dorisTranslationsViewModel.fastForward = translationsValue.fastForward
-            dorisTranslationsViewModel.off = translationsValue.off
-            dorisTranslationsViewModel.audioOnlyBadge = translationsValue.audioOnlyBadge
-            jsTranslations = JSTranslations(beaconTranslations: nil, dorisTranslations: dorisTranslationsViewModel)
-        }
-        return jsTranslations
+        guard let translations else { return nil }
+        let dorisTranslationsViewModel = convertRNVideoTranslationsToDorisTranslations(translations: translations)
+        return JSTranslations(beaconTranslations: nil, dorisTranslations: dorisTranslationsViewModel)
     }
-    
+
+    static func convertRNVideoTranslationsToDorisTranslations(translations: Translations) -> DorisTranslationsViewModel {
+        var dorisTranslationsViewModel = DorisTranslationsViewModel()
+        dorisTranslationsViewModel.play = translations.playerPlayButton
+        dorisTranslationsViewModel.pause = translations.playerPauseButton
+        dorisTranslationsViewModel.stats = translations.playerStatsButton
+        dorisTranslationsViewModel.audioAndSubtitles = translations.playerAudioAndSubtitlesButton
+        dorisTranslationsViewModel.live = translations.goLive
+        dorisTranslationsViewModel.favourites = translations.favourite
+        dorisTranslationsViewModel.addToWatchlist = translations.addToWatchlist
+        dorisTranslationsViewModel.moreVideos = translations.moreVideos
+        dorisTranslationsViewModel.audio = translations.audioTracks
+        dorisTranslationsViewModel.info = translations.info
+        dorisTranslationsViewModel.adsCountdownAd = translations.adsCountdownAd
+        dorisTranslationsViewModel.adsCountdownOf = translations.adsCountdownOf
+        dorisTranslationsViewModel.annotations = translations.annotations
+        dorisTranslationsViewModel.playingLive = translations.playingLive
+        dorisTranslationsViewModel.nowPlaying = translations.nowPlaying
+        dorisTranslationsViewModel.subtitles = translations.captions
+        dorisTranslationsViewModel.skipIntro = translations.skipIntro
+        dorisTranslationsViewModel.skipCredits = translations.skipCredits
+        dorisTranslationsViewModel.rewind = translations.rewind
+        dorisTranslationsViewModel.fastForward = translations.fastForward
+        dorisTranslationsViewModel.off = translations.off
+        dorisTranslationsViewModel.audioOnlyBadge = translations.audioOnlyBadge
+        return dorisTranslationsViewModel
+    }
+
     private static func convertRNVideoButtonsToRNDV(buttons: Buttons?) -> JSButtons? {
         var jsButtons: JSButtons?
         if let buttonsValue = buttons {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "7.7.6",
+    "version": "7.7.7",
     "dorisAndroidVersion": "3.13.6",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",


### PR DESCRIPTION
Sync translations to rndv if changed.
We need this because the favroute translations will be changed if favourite button is pressed during video playback.

[UTV-3277](https://dicetech.atlassian.net/browse/UTV-3277)

[UTV-3277]: https://dicetech.atlassian.net/browse/UTV-3277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ