### PR TITLE
[UTV-3379] Missing schedule translation

### DIFF
--- a/ios/Video/PlayerViewProxy.swift
+++ b/ios/Video/PlayerViewProxy.swift
@@ -110,6 +110,7 @@ class PlayerViewProxy {
         dorisTranslationsViewModel.fastForward = translations.fastForward
         dorisTranslationsViewModel.off = translations.off
         dorisTranslationsViewModel.audioOnlyBadge = translations.audioOnlyBadge
+        dorisTranslationsViewModel.schedule = translations.tvPlayerEPG
         return dorisTranslationsViewModel
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "7.7.11",
+    "version": "7.7.12",
     "dorisAndroidVersion": "3.13.8",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",


### PR DESCRIPTION
The schedule label is missing a translation.

[UTV-3379](https://dicetech.atlassian.net/browse/UTV-3379)

[UTV-3379]: https://dicetech.atlassian.net/browse/UTV-3379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ