### PR TITLE
UTV-3675: bottom overlay cause the crashes

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -1730,20 +1730,22 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
         // add frameLayout to ExoPlayerView, ReactRootView load data first, move to ExoPlayerControllerView.
         ReactRootFrameLayout frameLayout = new ReactRootFrameLayout(getContext());
         frameLayout.setOnSizeChangedListener((reactRootFrameLayout, childView) -> {
-            reactRootFrameLayout.removeView(childView);
-            childView.setLayoutParams(new FrameLayout.LayoutParams(
-                    width > 0 ? width : LayoutParams.WRAP_CONTENT,
-                    height > 0 ? height : LayoutParams.WRAP_CONTENT));
-            exoDorisPlayerView.setBottomComponentView(childView, view -> {
-                if (view != null) {
-                    String className = view.getClass().getName();
-                    if (className.equals("androidx.compose.ui.platform.AndroidComposeView")) {
-                        return true;
+            post(() -> {
+                reactRootFrameLayout.removeView(childView);
+                childView.setLayoutParams(new FrameLayout.LayoutParams(
+                        width > 0 ? width : LayoutParams.WRAP_CONTENT,
+                        height > 0 ? height : LayoutParams.WRAP_CONTENT));
+                exoDorisPlayerView.setBottomComponentView(childView, view -> {
+                    if (view != null) {
+                        String className = view.getClass().getName();
+                        if (className.equals("androidx.compose.ui.platform.AndroidComposeView")) {
+                            return true;
+                        }
                     }
-                }
-                return view instanceof ReactViewGroup;
+                    return view instanceof ReactViewGroup;
+                });
+                exoDorisPlayerView.removeView(reactRootFrameLayout);
             });
-            exoDorisPlayerView.removeView(reactRootFrameLayout);
         });
         ReactRootView reactRootView = new ReactRootView(getContext());
         reactRootView.setTag(R.id.bottom_overlay_component);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "7.10.4",
+    "version": "7.10.5",
     "dorisAndroidVersion": "3.14.2",
     "messagingAndroidVersion": "1.1.0",
     "description": "A <Video /> element for react-native",


### PR DESCRIPTION
## Description
The `removeView` function is called during the `layout` loop the children and causes the number of children changed, so the crash happened.
Post the `removeView` will resolve the crash

```
FATAL EXCEPTION: main
  Process: com.uefa.uefatv.androidtv, PID: 19689
  java.lang.NullPointerException: Attempt to invoke virtual method 'int android.view.View.getVisibility()' on a null object reference
   at android.widget.FrameLayout.layoutChildren(FrameLayout.java:284)
   at android.widget.FrameLayout.onLayout(FrameLayout.java:270)
   at android.view.View.layout(View.java:24421)
   at android.view.ViewGroup.layout(ViewGroup.java:6443)
   at android.widget.FrameLayout.layoutChildren(FrameLayout.java:332)
   at android.widget.FrameLayout.onLayout(FrameLayout.java:270)
   at android.view.View.layout(View.java:24421)
   at android.view.ViewGroup.layout(ViewGroup.java:6443)
   at com.brentvatne.exoplayer.ReactTVExoplayerView.manuallyLayoutChildren(ReactTVExoplayerView.java:423)
   at com.brentvatne.exoplayer.ReactTVExoplayerView.-$$Nest$mmanuallyLayoutChildren(Unknown Source:0)
   at com.brentvatne.exoplayer.ReactTVExoplayerView$4.doFrame(ReactTVExoplayerView.java:329)
   at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1337)
   at android.view.Choreographer$CallbackRecord.run(Choreographer.java:1348)
   at android.view.Choreographer.doCallbacks(Choreographer.java:952)
   at android.view.Choreographer.doFrame(Choreographer.java:878)
   at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1322)
   at android.os.Handler.handleCallback(Handler.java:958)
   at android.os.Handler.dispatchMessage(Handler.java:99)
   at android.os.Looper.loopOnce(Looper.java:205)
   at android.os.Looper.loop(Looper.java:294)
   at android.app.ActivityThread.main(ActivityThread.java:8177)
   at java.lang.reflect.Method.invoke(Native Method)
   at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
   at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971)
```


## Jira
[UTV-3675](https://dicetech.atlassian.net/browse/UTV-3675)


[UTV-3675]: https://dicetech.atlassian.net/browse/UTV-3675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ