### PR TITLE
fix: disable pause for pure live streaming on TV

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -81,6 +81,7 @@ import com.diceplatform.doris.entity.SourceBuilder;
 import com.diceplatform.doris.entity.TextTrack;
 import com.diceplatform.doris.entity.Track;
 import com.diceplatform.doris.entity.TracksPolicy;
+import com.diceplatform.doris.entity.VideoType;
 import com.diceplatform.doris.entity.YoSsaiProperties;
 import com.diceplatform.doris.ext.imacsailive.ExoDorisImaCsaiLivePlayer;
 import com.diceplatform.doris.internal.ResumePositionHandler;
@@ -813,7 +814,9 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
             public void onPause() {
                 super.onPause();
                 Log.d(TAG, "MediaSession onPause()");
-                setPausedModifier(true);
+                if (player == null || !isLive || player.getCurrentVideoType() == VideoType.LIVE_WITH_DVR){
+                  setPausedModifier(true);
+                }
             }
         });
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
-    "version": "7.10.12",
-    "dorisAndroidVersion": "3.14.6",
+    "version": "7.10.13",
+    "dorisAndroidVersion": "3.14.8",
     "messagingAndroidVersion": "1.1.0",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",


### PR DESCRIPTION
## Description

Disable the pause key event for pure live streaming on TV

## JIRA

[UTV-3914](https://dicetech.atlassian.net/browse/UTV-3914)

## Screenshot

If relevant

[UTV-3914]: https://dicetech.atlassian.net/browse/UTV-3914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ