### PR TITLE
chore: bump doris-android

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
-    "version": "7.12.11",
-    "dorisAndroidVersion": "5.2.9",
+    "version": "7.12.12",
+    "dorisAndroidVersion": "5.2.15",
     "messagingAndroidVersion": "1.1.0",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",


### PR DESCRIPTION
* Bump `doris-android` to fix the skip intros displayed over ad overlays issue

Ticket: https://dicetech.atlassian.net/browse/DORIS-3240