### PR TITLE
feat: support forced subtitle on android tv

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
-    "version": "7.12.17",
-    "dorisAndroidVersion": "5.2.20",
+    "version": "7.12.18",
+    "dorisAndroidVersion": "5.2.22",
     "messagingAndroidVersion": "1.1.0",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",


### PR DESCRIPTION
Ticket: https://dicetech.atlassian.net/browse/DORIS-3269

- filter out any forced subtitles tracks so they no longer appear in the UI overlay
- when no regular subtitle track is selected (Subtitles “off”) then display the forced subtitle track if it exists for the currently playing audio track
- ignore forced subtitles if there is a track policy for the expected audio