### PR TITLE
fix: support shouldAutoStart from video data config

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -206,6 +206,7 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
     private boolean hideAdUiElements;
     private boolean isWhyThisAdIconEnabled;
     private boolean isPlayPauseEnabled = true;
+    private boolean shouldAutoStart = true;
     private float jsProgressUpdateInterval = 250.0f;
     // \ End props
 
@@ -551,9 +552,12 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
             player = exoDorisFactory.createPlayer(
                     getContext(),
                     adType,
+                    shouldAutoStart,
+                    null,
                     MAX_LOAD_BUFFER_MS,
                     dvrSeekForwardInterval != 0L ? dvrSeekForwardInterval : exoDorisPlayerView.getFastForwardIncrementMs(),
                     dvrSeekBackwardInterval != 0L ? dvrSeekBackwardInterval : exoDorisPlayerView.getRewindIncrementMs(),
+                    null,
                     adViewProvider,
                     exoDorisPlayerView,
                     src.getTracksPolicy());
@@ -608,6 +612,7 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
             sourceBuilder
                     .setId(src.getId())
                     .setUrl(src.getUrl())
+                    .setShouldPlayWhenReady(shouldAutoStart)
                     .setMimeType(src.getMimeType())
                     .setYoSsaiProperties(src.getYoSsai())
                     .setAmtSsaiProperties(src.getAmtSsai())
@@ -1879,6 +1884,10 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
     public void setPlayPauseEnabled(boolean playPauseEnabled) {
         isPlayPauseEnabled = playPauseEnabled;
         exoDorisPlayerView.setPlayPauseEnabled(playPauseEnabled);
+    }
+
+    public void setShouldAutoStart(boolean shouldAutoStart) {
+        this.shouldAutoStart = shouldAutoStart;
     }
 
     private boolean isUnauthorizedAdError(Exception error) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
@@ -148,6 +148,7 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
     private static final String PROP_LOCALE = "locale";
     private static final String PROP_IS4K = "is4K";
     private static final String PROP_IS_PLAY_PAUSE_ENABLED = "isPlayPauseEnabled";
+    private static final String PROP_SHOULD_AUTO_START = "shouldAutoStart";
 
     private static final int COMMAND_SEEK_TO_POSITION = 4;
     private static final int COMMAND_REPLACE_AD_TAG_PARAMETERS = 5;
@@ -642,6 +643,11 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
     @ReactProp(name = PROP_IS_PLAY_PAUSE_ENABLED)
     public void setIsPlayPauseEnabled(final ReactTVExoplayerView videoView, boolean isPlayPauseEnabled) {
         videoView.setPlayPauseEnabled(isPlayPauseEnabled);
+    }
+
+    @ReactProp(name = PROP_SHOULD_AUTO_START)
+    public void setShouldAutoStart(final ReactTVExoplayerView videoView, boolean shouldAutoStart){
+        videoView.setShouldAutoStart(shouldAutoStart);
     }
 
     private boolean startsWithValidScheme(String uriString) {

--- a/ios/JSProps/JSProps.swift
+++ b/ios/JSProps/JSProps.swift
@@ -24,7 +24,8 @@ class JSProps {
     var hideAdUiElements: Dynamic<Bool> = Dynamic(false)
     var isWhyThisAdIconEnabled: Dynamic<Bool> = Dynamic(false)
     var locale: Dynamic<String?> = Dynamic(nil)
-    var isPlayPauseEnabled: Dynamic<Bool> = Dynamic(true)  
+    var isPlayPauseEnabled: Dynamic<Bool> = Dynamic(true)
+    var shouldAutoStart: Dynamic<Bool> = Dynamic(true)
 }
 
 class Dynamic<T> {

--- a/ios/Video/NewPlayerView.swift
+++ b/ios/Video/NewPlayerView.swift
@@ -15,6 +15,7 @@ class NewPlayerView: UIView, JSInputProtocol {
     //Events
     //used
     @objc var onBackButton: RCTBubblingEventBlock?
+    @objc var onVideoLoadStart: RCTBubblingEventBlock?
     @objc var onVideoLoad: RCTBubblingEventBlock?
     @objc var onVideoError: RCTBubblingEventBlock?
     @objc var onVideoProgress: RCTBubblingEventBlock?
@@ -38,7 +39,6 @@ class NewPlayerView: UIView, JSInputProtocol {
     @objc var onPlayPauseAction: RCTBubblingEventBlock?
 
     //not used
-    @objc var onVideoLoadStart: RCTBubblingEventBlock?
     @objc var onTimedMetadata: RCTBubblingEventBlock?
     @objc var onVideoAudioBecomingNoisy: RCTBubblingEventBlock?
     @objc var onVideoFullscreenPlayerWillPresent: RCTBubblingEventBlock?
@@ -153,7 +153,13 @@ class NewPlayerView: UIView, JSInputProtocol {
             jsProps.isPlayPauseEnabled.value = isPlayPauseEnabled
         }
     }
-    
+
+    @objc var shouldAutoStart: Bool = true {
+        didSet {
+            jsProps.shouldAutoStart.value = shouldAutoStart
+        }
+    }
+
     //FIXME: review unused variables
     @objc var selectedTextTrack: NSDictionary?
     @objc var selectedAudioTrack: NSDictionary?
@@ -206,7 +212,10 @@ class NewPlayerView: UIView, JSInputProtocol {
         jsPlayerView.onBackButton = self.onBackButton
         jsPlayerView.onVideoError = self.onVideoError
         jsPlayerView.onRequireAdParameters = self.onRequireAdParameters
-        jsPlayerView.onVideoLoad = self.onVideoLoad
+        // in RNDV, onVideoLoad fires when load initiated
+        jsPlayerView.onVideoLoad = self.onVideoLoadStart
+        // in RNDV, onVideoStart fires when the video loaded and about to play
+        jsPlayerView.onVideoStart = self.onVideoLoad
         jsPlayerView.onSubtitleTrackChanged = self.onSubtitleTrackChanged
         jsPlayerView.onAudioTrackChanged = self.onAudioTrackChanged
         jsPlayerView.isMuted = self.muted

--- a/ios/Video/PlayerViewProxy.swift
+++ b/ios/Video/PlayerViewProxy.swift
@@ -289,8 +289,10 @@ class PlayerViewProxy {
             seekBackwardInterval: seekBackwardInterval,
             hideAdUiElements: jsProps.hideAdUiElements.value,
             isWhyThisAdIconEnabled: jsProps.isWhyThisAdIconEnabled.value,
-            isPlayPauseEnabled: jsProps.isPlayPauseEnabled.value)
-        
+            isPlayPauseEnabled: jsProps.isPlayPauseEnabled.value,
+            shouldAutoStart: jsProps.shouldAutoStart.value
+        )
+
         if let rndvJSSource = rndvJSSource {
             let jsVideoData = RNDReactNativeDiceVideo.JSVideoData(source: rndvJSSource, config: rndvJSVideoDataConfig)
             rndvJsProps.videoData.value = jsVideoData

--- a/ios/Video/RCTVideoManager.m
+++ b/ios/Video/RCTVideoManager.m
@@ -34,6 +34,7 @@ RCT_EXPORT_VIEW_PROPERTY(hideAdUiElements, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(isWhyThisAdIconEnabled, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(locale, NSString);
 RCT_EXPORT_VIEW_PROPERTY(isPlayPauseEnabled, BOOL);
+RCT_EXPORT_VIEW_PROPERTY(shouldAutoStart, BOOL);
 
 /* Should support: onLoadStart, onLoad, and onError to stay consistent with Image */
 RCT_EXPORT_VIEW_PROPERTY(onVideoLoadStart, RCTBubblingEventBlock);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
     "version": "7.12.20",
-    "dorisAndroidVersion": "5.2.23",
+    "dorisAndroidVersion": "5.2.25",
     "messagingAndroidVersion": "1.1.0",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "7.12.19",
+    "version": "7.12.20",
     "dorisAndroidVersion": "5.2.23",
     "messagingAndroidVersion": "1.1.0",
     "description": "A <Video /> element for react-native",
@@ -21,7 +21,7 @@
         "eslint-plugin-react": "3.16.1"
     },
     "dependencies": {
-        "@dicetechnology/react-native-dice-video": "git+ssh://git@github.com/DiceTechnology/react-native-dice-video.git#7.4.20",
+        "@dicetechnology/react-native-dice-video": "git+ssh://git@github.com/DiceTechnology/react-native-dice-video.git#fix/auto-start-from-config",
         "@dicetechnology/dice-unity": "^2.26.3",
         "keymirror": "0.1.1",
         "prop-types": "^15.5.10"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "eslint-plugin-react": "3.16.1"
     },
     "dependencies": {
-        "@dicetechnology/react-native-dice-video": "git+ssh://git@github.com/DiceTechnology/react-native-dice-video.git#fix/auto-start-from-config",
+        "@dicetechnology/react-native-dice-video": "git+ssh://git@github.com/DiceTechnology/react-native-dice-video.git#7.4.24",
         "@dicetechnology/dice-unity": "^2.26.3",
         "keymirror": "0.1.1",
         "prop-types": "^15.5.10"

--- a/types/callbacks.ts
+++ b/types/callbacks.ts
@@ -1,3 +1,4 @@
+import { IVideoPlayerPlayPauseEvent, IVideoPlayerSeekEndedEvent } from "./event";
 import { IVideoPlayerOnRequireAdParametersPayload } from "./ima";
 
 export interface IVideoPlayerCallbacks {
@@ -18,7 +19,7 @@ export interface IVideoPlayerCallbacks {
   onRelatedVideosIconClicked?: (e: any) => void;
   onRequireAdParameters?: (e: IVideoPlayerOnRequireAdParametersPayload) => void;
   onSeek?: (e: any) => void;
-  onSeekEndedEvent?: (e: any) => void;
+  onSeekEndedEvent?: (e: IVideoPlayerSeekEndedEvent) => void;
   onStatsIconClick?: () => void;
   onTimedMetadata?: (e: any) => void;
   onVideoAboutToEnd?: (e: any) => void;
@@ -28,5 +29,5 @@ export interface IVideoPlayerCallbacks {
   onAudioTrackChanged?: ({ language }: { language: string }) => void;
   onSubtitleTrackChanged?: ({ language }: { language: string }) => void;
   onSkipMarkerButton?: (e: any) => void;
-  onPlayPauseAction?: (e: any) => void;
+  onPlayPauseAction?: (e: IVideoPlayerPlayPauseEvent) => void;
 }

--- a/types/event.ts
+++ b/types/event.ts
@@ -1,0 +1,16 @@
+
+export enum IVideoPlayerSeekType {
+  SKIP = "skip",
+  SEEK = "seek",
+  GO_LIVE = "liveBadge",
+}
+
+export interface IVideoPlayerSeekEndedEvent {
+  seekType: IVideoPlayerSeekType;
+  seekStartAt: number;
+  seekEndAt: number;
+};
+
+export interface IVideoPlayerPlayPauseEvent {
+  isPaused: boolean;
+};

--- a/types/event.ts
+++ b/types/event.ts
@@ -3,6 +3,7 @@ export enum IVideoPlayerSeekType {
   SKIP = "skip",
   SEEK = "seek",
   GO_LIVE = "liveBadge",
+  SKIP_MARKER = "skipMarker",
 }
 
 export interface IVideoPlayerSeekEndedEvent {

--- a/types/player.ts
+++ b/types/player.ts
@@ -46,4 +46,5 @@ export interface IVideoPlayer extends IVideoPlayerCallbacks, ViewProps {
   width?: number;
   subtitleHorizontalPadding?: number;
   isPlayPauseEnabled?: boolean;
+  shouldAutoStart?: boolean;
 }


### PR DESCRIPTION
- Support `shouldAutoStart` to fix issue for the audio starts before video on animated hero.
- Add some event type

[UTV-4060](https://dicetech.atlassian.net/browse/UTV-4060)

[UTV-4060]: https://dicetech.atlassian.net/browse/UTV-4060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ