### PR TITLE
fix: add shouldAutoStart param to control when to start video

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -206,6 +206,7 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
     private boolean hideAdUiElements;
     private boolean isWhyThisAdIconEnabled;
     private boolean isPlayPauseEnabled = true;
+    private boolean shouldAutoStart = true;
     private float jsProgressUpdateInterval = 250.0f;
     // \ End props
 
@@ -551,9 +552,12 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
             player = exoDorisFactory.createPlayer(
                     getContext(),
                     adType,
+                    shouldAutoStart,
+                    null,
                     MAX_LOAD_BUFFER_MS,
                     dvrSeekForwardInterval != 0L ? dvrSeekForwardInterval : exoDorisPlayerView.getFastForwardIncrementMs(),
                     dvrSeekBackwardInterval != 0L ? dvrSeekBackwardInterval : exoDorisPlayerView.getRewindIncrementMs(),
+                    null,
                     adViewProvider,
                     exoDorisPlayerView,
                     src.getTracksPolicy());
@@ -608,6 +612,7 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
             sourceBuilder
                     .setId(src.getId())
                     .setUrl(src.getUrl())
+                    .setShouldPlayWhenReady(shouldAutoStart)
                     .setMimeType(src.getMimeType())
                     .setYoSsaiProperties(src.getYoSsai())
                     .setAmtSsaiProperties(src.getAmtSsai())
@@ -1879,6 +1884,10 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
     public void setPlayPauseEnabled(boolean playPauseEnabled) {
         isPlayPauseEnabled = playPauseEnabled;
         exoDorisPlayerView.setPlayPauseEnabled(playPauseEnabled);
+    }
+
+    public void setShouldAutoStart(boolean shouldAutoStart) {
+        this.shouldAutoStart = shouldAutoStart;
     }
 
     private boolean isUnauthorizedAdError(Exception error) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerViewManager.java
@@ -148,6 +148,7 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
     private static final String PROP_LOCALE = "locale";
     private static final String PROP_IS4K = "is4K";
     private static final String PROP_IS_PLAY_PAUSE_ENABLED = "isPlayPauseEnabled";
+    private static final String PROP_SHOULD_AUTO_START = "shouldAutoStart";
 
     private static final int COMMAND_SEEK_TO_POSITION = 4;
     private static final int COMMAND_REPLACE_AD_TAG_PARAMETERS = 5;
@@ -642,6 +643,11 @@ public class ReactTVExoplayerViewManager extends ViewGroupManager<ReactTVExoplay
     @ReactProp(name = PROP_IS_PLAY_PAUSE_ENABLED)
     public void setIsPlayPauseEnabled(final ReactTVExoplayerView videoView, boolean isPlayPauseEnabled) {
         videoView.setPlayPauseEnabled(isPlayPauseEnabled);
+    }
+
+    @ReactProp(name = PROP_SHOULD_AUTO_START)
+    public void setShouldAutoStart(final ReactTVExoplayerView videoView, boolean shouldAutoStart){
+        videoView.setShouldAutoStart(shouldAutoStart);
     }
 
     private boolean startsWithValidScheme(String uriString) {


### PR DESCRIPTION
add `shouldAutoStart` field, get from Js side. 

Fix aljazeera home page hero video delay start.

Ticket: [UTV-4060](https://dicetech.atlassian.net/browse/UTV-4060)

[UTV-4060]: https://dicetech.atlassian.net/browse/UTV-4060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ