### PR TITLE
[UTV-4392] Android: Fix subtitle policy logic

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -1466,20 +1466,31 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
         this.repeat = repeat;
     }
 
-    private void selectTrack(TracksPolicy.TrackPolicy trackPolicy, int trackType, @Nullable List<String> preferredLanguages) {
+    private void selectTrack(int trackType, @Nullable List<String> preferredLanguages) {
         Track track = null;
         List<Track> trackList = getTracks(player.getExoPlayer().getCurrentTracks());
         if (trackType == C.TRACK_TYPE_TEXT) {
-            if (preferredLanguages == null || preferredLanguages.isEmpty() || preferredLanguages.get(0) == null) { // "OFF" or user not select preferred subtitle
-                if (trackPolicy != null) { // track policy is active, select track policy subtitle
-                    track = TrackUtils.findMatchingTrack(localizationService, trackList, trackType, trackPolicy.getSubtitle());
-                }
-            } else { // select user preferred subtitle
-                track = TrackUtils.findMatchingTrack(localizationService, trackList, trackType, preferredLanguages.get(0));
+            if (preferredLanguages != null
+                    && !preferredLanguages.isEmpty()
+                    && preferredLanguages.get(0) != null) {
+
+                track = TrackUtils.findMatchingTrack(
+                        localizationService,
+                        trackList,
+                        trackType,
+                        preferredLanguages.get(0)
+                );
             }
         } else if (trackType == C.TRACK_TYPE_AUDIO) {
-            if (preferredLanguages != null && !preferredLanguages.isEmpty() && preferredLanguages.get(0) != null) {
-                track = TrackUtils.findMatchingTrack(localizationService, trackList, trackType, preferredLanguages.get(0));
+            if (preferredLanguages != null
+                    && !preferredLanguages.isEmpty()
+                    && preferredLanguages.get(0) != null) {
+                track = TrackUtils.findMatchingTrack(
+                        localizationService,
+                        trackList,
+                        trackType,
+                        preferredLanguages.get(0)
+                );
             }
         }
         if (track != null) {
@@ -2032,13 +2043,9 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
             } else if (playerEvent instanceof DorisPlayerEvent.TrackInfoChanged) {
                 if (selectUserPreferredTrack) {
                     selectUserPreferredTrack = false;
-                    // check track policy
-                    Tracks tracks = player.getExoPlayer().getCurrentTracks();
-                    TracksPolicy.TrackPolicy trackPolicy = getTrackPolicy(trackSelector, tracks, getPreferredAudioLang());
-
                     // Preselect subtitle and audio.
-                    selectTrack(trackPolicy, C.TRACK_TYPE_TEXT, getPreferredSubtitleLang());
-                    selectTrack(trackPolicy, C.TRACK_TYPE_AUDIO, getPreferredAudioLang());
+                    selectTrack(C.TRACK_TYPE_TEXT, getPreferredSubtitleLang());
+                    selectTrack(C.TRACK_TYPE_AUDIO, getPreferredAudioLang());
                 }
             } else if (playerEvent instanceof DorisPlayerEvent.TimelineAdjusterChanged) {
                 if (exoDorisPlayerView != null) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
-    "version": "7.12.22",
-    "dorisAndroidVersion": "5.2.26",
+    "version": "7.12.23",
+    "dorisAndroidVersion": "5.2.26-hotfix",
     "messagingAndroidVersion": "1.1.0",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",


### PR DESCRIPTION
On Hidive we have the following subtitle policy (from /init API):
```
"audioSubtitleLanguages": {
            "audioToSubtitleLanguages": {
                "JPN": "ENG",
                "UND": "ENG"
            }
        },
```
Previously, when the JPN audio track was selected, we automatically switched the subtitles to the corresponding ENG track, based on the subtitle policy.
The correct behavior, however, is to only switch to the ENG subtitle if the current subtitle selection is OFF.

The following remained unchanged:
When a subtitle-policy audio track is selected (e.g., JPN), the OFF subtitle option is hidden per requirements.

Ticket: https://dicetech.atlassian.net/browse/DEV-6699
Bump `doris-android` to [5.2.26-hotfix](https://github.com/DiceTechnology/doris-android/releases/tag/5.2.26-hotfix)