### PR TITLE
chore: bump to `rndv` 7.5.1 and `doris-android` 5.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "7.12.26",
+    "version": "7.13.0",
     "dorisAndroidVersion": "5.2.26-hotfix-2",
     "messagingAndroidVersion": "1.1.0",
     "description": "A <Video /> element for react-native",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "eslint-plugin-react": "3.16.1"
     },
     "dependencies": {
-        "@dicetechnology/react-native-dice-video": "git+ssh://git@github.com/DiceTechnology/react-native-dice-video.git#7.4.25-hotfix.2",
+        "@dicetechnology/react-native-dice-video": "git+ssh://git@github.com/DiceTechnology/react-native-dice-video.git#7.5.0",
         "@dicetechnology/dice-unity": "^2.26.3",
         "keymirror": "0.1.1",
         "prop-types": "^15.5.10"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
     "version": "7.13.0",
-    "dorisAndroidVersion": "5.2.26-hotfix-2",
+    "dorisAndroidVersion": "5.4.1",
     "messagingAndroidVersion": "1.1.0",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",
@@ -21,7 +21,7 @@
         "eslint-plugin-react": "3.16.1"
     },
     "dependencies": {
-        "@dicetechnology/react-native-dice-video": "git+ssh://git@github.com/DiceTechnology/react-native-dice-video.git#7.5.0",
+        "@dicetechnology/react-native-dice-video": "git+ssh://git@github.com/DiceTechnology/react-native-dice-video.git#7.5.1",
         "@dicetechnology/dice-unity": "^2.26.3",
         "keymirror": "0.1.1",
         "prop-types": "^15.5.10"


### PR DESCRIPTION
### Bug fix
- DORIS-3304: [Android] Fix segmented webvtt shows only first segment on DASH
- DORIS-3323: [Android] Enhance track language match logic for forced subtitltes
- DORIS-3318: [Android] Explicitly stop MUX session on fatal playback error

### Feature
- DORIS-3198: [Android]: Add support for non-linear ads (pause ads)
- DORIS-3246: [Android]: Add support for forced subtitles
- DORIS-3248 [iOS] Add forced subtitles support