### PR TITLE
[UTV-4419] Subtitle/audio track change event

### DIFF
--- a/Video.tsx
+++ b/Video.tsx
@@ -158,6 +158,14 @@ export default class Video extends React.PureComponent<IVideoPlayer, IState> {
     this.props.onBehindLiveWindowError?.(event.nativeEvent);
   }
 
+  onAudioTrackChanged = (event) => { 
+    this.props.onAudioTrackChanged?.(event.nativeEvent);
+  }
+
+  onSubtitleTrackChanged = (event) => {
+    this.props.onSubtitleTrackChanged?.(event.nativeEvent);
+  }
+
   /**
    * @description seeks to a specified time in the video
    * @param time video time in seconds
@@ -214,6 +222,8 @@ export default class Video extends React.PureComponent<IVideoPlayer, IState> {
       onBehindLiveWindowError: this.onBehindLiveWindowError,
       onSkipMarkerButton: this.onSkipMarkerButton,
       onPlayPauseAction: this.onPlayPauseAction,
+      onAudioTrackChanged: this.onAudioTrackChanged,
+      onSubtitleTrackChanged: this.onSubtitleTrackChanged,
     };
   };
 

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -1979,21 +1979,21 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
     }
 
     @Override
-    public void onSubtitleSelected(String language) {
+    public void onSubtitleSelected(String language, boolean userInitiated) {
         TrackPreferenceStorage storage = TrackPreferenceStorage.getInstance(getContext());
         storage.storePreferredSubtitleLanguage(language == null
                 ? TrackPreferenceStorage.NONE
                 : language);
-        eventEmitter.subtitleTrackChanged(language);
+        eventEmitter.subtitleTrackChanged(language, userInitiated);
     }
 
     @Override
-    public void onAudioSelected(String language) {
+    public void onAudioSelected(String language, boolean userInitiated) {
         TrackPreferenceStorage storage = TrackPreferenceStorage.getInstance(getContext());
         storage.storePreferredAudioLanguage(language == null
                 ? TrackPreferenceStorage.NONE
                 : language);
-        eventEmitter.audioTrackChanged(language);
+        eventEmitter.audioTrackChanged(language, userInitiated);
     }
 
     public void replaceAdTagParameters(Map<String, Object> replaceAdTagParametersMap) {

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/VideoEventEmitter.java
@@ -192,6 +192,7 @@ class VideoEventEmitter {
     private static final String EVENT_PROP_DATE = "date";
     private static final String EVENT_PROP_IS_BLOCKING = "isBlocking";
     private static final String EVENT_PROP_LANGUAGE = "language";
+    private static final String EVENT_PROP_ACTION = "action";
     private static final String EVENT_PROP_TARGET = "target";
 
     private static final String EVENT_PROP_ERROR = "error";
@@ -457,16 +458,32 @@ class VideoEventEmitter {
         receiveEvent(EVENT_ANNOTATIONS_BUTTON_CLICK, null);
     }
 
-    void subtitleTrackChanged(String language) {
+    void subtitleTrackChanged(String language, boolean userInitiated) {
+        // when user select subtitle, track 'ui' 'player' twice events. matching as TvOS.
         String lang = "OFF".equalsIgnoreCase(language) ? "" : language;
+        if (userInitiated) {
+            WritableMap map = Arguments.createMap();
+            map.putString(EVENT_PROP_LANGUAGE, lang);
+            map.putString(EVENT_PROP_ACTION, "ui");
+            receiveEvent(EVENT_SUBTITLE_TRACK_CHANGED, map);
+        }
         WritableMap map = Arguments.createMap();
         map.putString(EVENT_PROP_LANGUAGE, lang);
+        map.putString(EVENT_PROP_ACTION, "player");
         receiveEvent(EVENT_SUBTITLE_TRACK_CHANGED, map);
     }
 
-    void audioTrackChanged(String language) {
+    void audioTrackChanged(String language, boolean userInitiated) {
+        // when user select subtitle, track 'ui' 'player' twice events. matching as TvOS.
+        if (userInitiated) {
+            WritableMap map = Arguments.createMap();
+            map.putString(EVENT_PROP_LANGUAGE, language);
+            map.putString(EVENT_PROP_ACTION, "ui");
+            receiveEvent(EVENT_AUDIO_TRACK_CHANGED, map);
+        }
         WritableMap map = Arguments.createMap();
         map.putString(EVENT_PROP_LANGUAGE, language);
+        map.putString(EVENT_PROP_ACTION, "player");
         receiveEvent(EVENT_AUDIO_TRACK_CHANGED, map);
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "7.13.0",
+    "version": "7.13.1",
     "dorisAndroidVersion": "5.4.1",
     "messagingAndroidVersion": "1.1.0",
     "description": "A <Video /> element for react-native",
@@ -21,7 +21,7 @@
         "eslint-plugin-react": "3.16.1"
     },
     "dependencies": {
-        "@dicetechnology/react-native-dice-video": "git+ssh://git@github.com/DiceTechnology/react-native-dice-video.git#7.5.1",
+        "@dicetechnology/react-native-dice-video": "git+ssh://git@github.com/DiceTechnology/react-native-dice-video.git#7.5.2",
         "@dicetechnology/dice-unity": "^2.26.3",
         "keymirror": "0.1.1",
         "prop-types": "^15.5.10"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
     "version": "7.13.1",
-    "dorisAndroidVersion": "0.0.251204-d0ba80b",
+    "dorisAndroidVersion": "5.4.3",
     "messagingAndroidVersion": "1.1.0",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
     "version": "7.13.0",
-    "dorisAndroidVersion": "5.4.1",
+    "dorisAndroidVersion": "0.0.251204-d0ba80b",
     "messagingAndroidVersion": "1.1.0",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",

--- a/types/callbacks.ts
+++ b/types/callbacks.ts
@@ -1,4 +1,4 @@
-import { IVideoPlayerPlayPauseEvent, IVideoPlayerSeekEndedEvent } from "./event";
+import { IVideoPlayerMediaTrackChangedEvent, IVideoPlayerPlayPauseEvent, IVideoPlayerSeekEndedEvent } from "./event";
 import { IVideoPlayerOnRequireAdParametersPayload } from "./ima";
 
 export interface IVideoPlayerCallbacks {
@@ -26,8 +26,8 @@ export interface IVideoPlayerCallbacks {
   onWatchlistButtonClick?: (e: any) => void;
   onReloadCurrentSource?: (e: any) => void;
   onBehindLiveWindowError?: (e: any) => void;
-  onAudioTrackChanged?: ({ language }: { language: string }) => void;
-  onSubtitleTrackChanged?: ({ language }: { language: string }) => void;
+  onAudioTrackChanged?: (e: IVideoPlayerMediaTrackChangedEvent) => void;
+  onSubtitleTrackChanged?: (e: IVideoPlayerMediaTrackChangedEvent) => void;
   onSkipMarkerButton?: (e: any) => void;
   onPlayPauseAction?: (e: IVideoPlayerPlayPauseEvent) => void;
 }

--- a/types/event.ts
+++ b/types/event.ts
@@ -7,8 +7,8 @@ export enum IVideoPlayerSeekType {
 }
 
 export enum IVideoPlayerMediaTrackAction {
-  USER = "user",
-  SYSTEM = "system",
+  UI = "ui",
+  PLAYER = "player",
 }
 
 export interface IVideoPlayerSeekEndedEvent {

--- a/types/event.ts
+++ b/types/event.ts
@@ -6,6 +6,11 @@ export enum IVideoPlayerSeekType {
   SKIP_MARKER = "skipMarker",
 }
 
+export enum IVideoPlayerMediaTrackAction {
+  USER = "user",
+  SYSTEM = "system",
+}
+
 export interface IVideoPlayerSeekEndedEvent {
   seekType: IVideoPlayerSeekType;
   seekStartAt: number;
@@ -15,3 +20,8 @@ export interface IVideoPlayerSeekEndedEvent {
 export interface IVideoPlayerPlayPauseEvent {
   isPaused: boolean;
 };
+
+export interface IVideoPlayerMediaTrackChangedEvent {
+  language: string;
+  action: IVideoPlayerMediaTrackAction;
+}


### PR DESCRIPTION

- Add `action=ui/player` to `onSubtitleTrackChanged/onAudioTrackChanged` event.
   * When user switched subtitle/audio language in the player, an event of `onSubtitleTrackChanged/onAudioTrackChanged` will be fired with `action=ui`. 
  * Each time the subtitle/audio language changed in the player, no matter it's triggered by user action or track policy or some reason else, an event of `onSubtitleTrackChanged/onAudioTrackChanged` will be fired with `action=player`. 
- Typed `onSubtitleTrackChanged/onAudioTrackChanged` event.

## JIRA
[UTV-4419](https://dicetech.atlassian.net/browse/UTV-4419)

[UTV-4419]: https://dicetech.atlassian.net/browse/UTV-4419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ