### PR TITLE
fix subtitle display name in android tv.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
-    "version": "7.13.2",
-    "dorisAndroidVersion": "5.4.3",
+    "version": "7.13.3",
+    "dorisAndroidVersion": "5.4.5",
     "messagingAndroidVersion": "1.1.0",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",


### PR DESCRIPTION
## Description

subtitle and audio display name

## JIRA

[DORIS-3426](https://dicetech.atlassian.net/browse/DORIS-3426)

## Screenshot

Before:
<img width="1920" height="1080" alt="Screenshot_20251218_105013" src="https://github.com/user-attachments/assets/d300a4e5-0180-4a70-99ec-2c20af6733a9" />

<img width="1080" height="1920" alt="Screenshot_20251218_135615" src="https://github.com/user-attachments/assets/2a68cab9-f142-49bc-8989-018aaedb9b2e" />

Now:
<img width="1920" height="1080" alt="Screenshot_20251218_105433" src="https://github.com/user-attachments/assets/ae0c4f38-9337-4f46-bbfb-f9bed9969455" />

<img width="1080" height="1920" alt="Screenshot_20251218_164851" src="https://github.com/user-attachments/assets/498de245-e21c-428b-85e6-876a4d849f7a" />



[DORIS-3426]: https://dicetech.atlassian.net/browse/DORIS-3426?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ