### PR TITLE
Fix/csai live preroll display

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactTVExoplayerView.java
@@ -196,6 +196,7 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
     // Props from React
     private RNSource src;
     private ContentMetadata metadata;
+    private String locale;
     private boolean repeat;
     private boolean disableFocus;
     private boolean isLive = false;
@@ -685,6 +686,7 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
                 .setHideAdUiElements(hideAdUiElements)
                 .setWhyThisAdIconEnabled(isWhyThisAdIconEnabled)
                 .setAdLabels(adLabels)
+                .setAdLanguage(locale)
                 .setLoopPauseAdsEnabled(isLoopPauseAds)
                 .setPauseAdsEnabled(isPauseAdsEnabled && treatAllOverlayAdsAsPauseAds)
                 .build();
@@ -1702,6 +1704,7 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
     }
 
     public void setAppLanguageLocale(String locale) {
+        this.locale = locale;
         String languageCode = localizationService.getCanonicalLanguageCode(locale);
         if (languageCode != null) {
             // Update display language in LocalizationService
@@ -2047,6 +2050,11 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
                 exoDorisPlayerView.onAdEvent(adEvent);
             }
             if (adEvent instanceof DorisAdEvent.AdBreakStarted) {
+                // PlayerView does not expose SurfaceView, we should call setVisibility() and setPlayer().
+                if (isCsaiLiveEvent(adEvent)) {
+                    secondaryPlayerView.setVisibility(View.VISIBLE);
+                    exoDorisPlayerView.setVisibility(View.GONE);
+                }
                 if (areControlsAllowed) {
                     setControls(false);
                 }
@@ -2059,12 +2067,6 @@ class ReactTVExoplayerView extends FrameLayout implements LifecycleEventListener
                 }
                 if (areControlsAllowed) {
                     setControls(true);
-                }
-            } else if (adEvent instanceof DorisAdEvent.AdResumed) {
-                // PlayerView does not expose SurfaceView, we should call setVisibility() and setPlayer().
-                if (isCsaiLiveEvent(adEvent)) {
-                    secondaryPlayerView.setVisibility(View.VISIBLE);
-                    exoDorisPlayerView.setVisibility(View.GONE);
                 }
             } else if (adEvent instanceof DorisAdEvent.AdLoading) {
                 // PlayerView does not expose SurfaceView, we should call setVisibility() and setPlayer().

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
     "version": "7.14.6",
-    "dorisAndroidVersion": "5.6.4",
+    "dorisAndroidVersion": "0.0.260228-0d4372a",
     "messagingAndroidVersion": "1.1.0",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
     "version": "7.14.6",
-    "dorisAndroidVersion": "5.5.6",
+    "dorisAndroidVersion": "5.6.4",
     "messagingAndroidVersion": "1.1.0",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "react-native-video",
-    "version": "7.14.7",
-    "dorisAndroidVersion": "0.0.260228-0d4372a",
+    "version": "7.14.8",
+    "dorisAndroidVersion": "5.6.5",
     "messagingAndroidVersion": "1.1.0",
     "description": "A <Video /> element for react-native",
     "main": "Video.tsx",


### PR DESCRIPTION
Bump doris-android to 5.6.5:
- feat: send csai ad events to mux manually same as SSAI 
- fix: csai live preroll display issue on TV

Tickets:
https://dicetech.atlassian.net/browse/DORIS-3541
https://dicetech.atlassian.net/browse/DORIS-3540