### PR TITLE
chore: bump RNDV

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-native-video",
-    "version": "7.14.9",
+    "version": "7.14.10",
     "dorisAndroidVersion": "5.6.5",
     "messagingAndroidVersion": "1.1.0",
     "description": "A <Video /> element for react-native",
@@ -21,7 +21,7 @@
         "eslint-plugin-react": "3.16.1"
     },
     "dependencies": {
-        "@dicetechnology/react-native-dice-video": "git+ssh://git@github.com/DiceTechnology/react-native-dice-video.git#7.8.5",
+        "@dicetechnology/react-native-dice-video": "git+ssh://git@github.com/DiceTechnology/react-native-dice-video.git#7.8.6",
         "@dicetechnology/dice-unity": "^2.26.3",
         "keymirror": "0.1.1",
         "prop-types": "^15.5.10"


### PR DESCRIPTION
### Bug fix
- DORIS-3457: [iOS] : Add the off and und labels to the LocalizationService
- DORIS-3560: [iOS] : remove off and und in MediaViewModel, use it from LocalizationService
